### PR TITLE
started iterator protocol definitions

### DIFF
--- a/src/type.jl
+++ b/src/type.jl
@@ -34,18 +34,10 @@ Base.length(ta::TimeArray) = length(ta.timestamp)
 
 ###### iterator protocol #########
 
-Base.start{T,N}(ta::TimeArray{T,N})   = 1
-#Base.next{T,N}(ta::TimeArray{T,N},i)  = (ta[i],i+1)
-#Base.next{T,N}(ta::TimeArray{T,N},i)  = (TimeArray(ta.timestamp[i],ta.values[i,:], ta.colnames),i+1)
-#Base.next{T,N}(ta::TimeArray{T,N},i)  = ((ta.timestamp[i],ta.values[i]),i+1)
-Base.next{T,N}(ta::TimeArray{T,N},i)  = ((ta.timestamp[i],ta.values[i,:]),i+1)
-Base.done{T,N}(ta::TimeArray{T,N},i)  = (i > length(ta))
-Base.isempty{T,N}(ta::TimeArray{T,N}) = (length(ta) == 0)
-
-# Base.start(ta::TimeArray)   = 1
-# Base.next(ta::TimeArray,i)  = (ta[i],i+1)
-# Base.done(ta::TimeArray,i)  = (i > length(ta))
-# Base.isempty(ta::TimeArray) = (length(ta) == 0)
+Base.start(ta::TimeArray)   = 1
+Base.next(ta::TimeArray,i)  = ((ta.timestamp[i],ta.values[i,:]),i+1)
+Base.done(ta::TimeArray,i)  = (i > length(ta))
+Base.isempty(ta::TimeArray) = (length(ta) == 0)
 
 ###### show #####################
  


### PR DESCRIPTION
This is odd behavior:

``` julia
julia> [c.timestamp for c in cl][1:3]
3-element Array{Array{Date{ISOCalendar},1},1}:
 [1980-01-03]
 [1980-01-04]
 [1980-01-07]

julia> [c.values for c in cl][1:3]
3-element Array{Array{Float64,1},1}:
 [105.22]
 [106.52]
 [106.81]
```

I wouldn't have expected iterating would create an array of arrays. 
