### PR TITLE
Use Symbols as column names

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -4,7 +4,7 @@
 for op in [:.+, :.-, :.*, :./]
   @eval begin
     function ($op){T,N}(ta1::TimeArray{T,N}, ta2::TimeArray{T,N})
-      cname  = [ta1.colnames[1][1:2] *  string($op) *  ta2.colnames[1][1:2]]
+      cname  = [string(ta1.colnames[1])[1:2] *  string($op) * string(ta2.colnames[1])[1:2]]
       tstamp = Date[]
       vals   = T[]
       for i in 1:size(ta1.timestamp, 1)
@@ -24,7 +24,7 @@ end # loop
 for op in [:.>, :.<, :.==, :.>=, :.<=]
   @eval begin
     function ($op){T,N}(ta1::TimeArray{T,N}, ta2::TimeArray{T,N})
-      cname  = [ta1.colnames[1][1:2] *  string($op) *  ta2.colnames[1][1:2]]
+      cname  = [string(ta1.colnames[1])[1:2] *  string($op) *  string(ta2.colnames[1])[1:2]]
       tstamp = Date[]
       vals   = Bool[]
       for i in 1:size(ta1.timestamp, 1)
@@ -64,7 +64,7 @@ end # loop
 for op in [:.>, :.<, :.==, :.>=, :.<=]
   @eval begin
     function ($op){T,N}(ta::TimeArray{T,N}, var::Union(Int,Float64))
-      cname  = [ta.colnames[1][1:2] *  string($op) *  string(var)]
+      cname  = [string(ta.colnames[1])[1:2] *  string($op) *  string(var)]
       tstamp = Date[]
       vals   = Bool[]
       for i in 1:length(ta)
@@ -79,7 +79,7 @@ end # loop
 for op in [:.>, :.<, :.==, :.>=, :.<=]
   @eval begin
     function ($op){T,N}(var::Union(Int,Float64), ta::TimeArray{T,N})
-      cname  = [ta.colnames[1][1:2] *  string($op) *  string(var)]
+      cname  = [string(ta.colnames[1])[1:2] *  string($op) *  string(var)]
       tstamp = Date[]
       vals   = Bool[]
       for i in 1:length(ta)

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -13,13 +13,13 @@ end
 facts("merge works correctly") do
 
    context("takes colnames kwarg correctly") do
-     @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[1] => "a"
-     @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[2] => "b"
-     @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[3] => "c"
-     @fact merge(cl,op, colnames=["a","b"]).colnames[1]                      => "a"
-     @fact merge(cl,op, colnames=["a","b"]).colnames[2]                      => "b"
-     @fact merge(cl,op, colnames=["a"]).colnames[1]                          => "Close"
-     @fact merge(cl,op, colnames=["a"]).colnames[2]                          => "Open"
+     @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[1] => :a
+     @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[2] => :b
+     @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[3] => :c
+     @fact merge(cl,op, colnames=["a","b"]).colnames[1]                      => :a
+     @fact merge(cl,op, colnames=["a","b"]).colnames[2]                      => :b
+     @fact merge(cl,op, colnames=["a"]).colnames[1]                          => :Close
+     @fact merge(cl,op, colnames=["a"]).colnames[2]                          => :Open
      @fact_throws merge(cl,op, colnames=["a","b","c"])
      @fact_throws merge(cl,op, colnames=["a","b","c"])
   end

--- a/test/split.jl
+++ b/test/split.jl
@@ -32,9 +32,9 @@ end
 facts("element wrappers") do
 
   context("type element wrappers isolate elements") do
-     @fact isa(timestamp(cl), Array{Date,1}) => true
-     @fact isa(values(cl), Array{Float64,1})              => true
-     @fact isa(values(ohlc), Array{Float64,2})            => true
-     @fact isa(colnames(cl), Array{UTF8String, 1})       => true
+     @fact isa(timestamp(cl), Array{Date,1})   => true
+     @fact isa(values(cl), Array{Float64,1})   => true
+     @fact isa(values(ohlc), Array{Float64,2}) => true
+     @fact isa(colnames(cl), Array{Symbol, 1}) => true
   end
 end


### PR DESCRIPTION
fixes #134

Should work as before when passing strings as column names: they're cast as symbols.

New to Julia so comments/thoughts/pointers welcome.

*Now I think about it maybe should also check identifiers (again inline with DataFrames), but I don't think there is a Base implementation of that yet?...*