### PR TITLE
adding faster merge1

### DIFF
--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -16,7 +16,7 @@ export TimeArray, AbstractTimeSeries,
        by, from, to, findwhen, findall, timestamp, values, colnames, 
        lag, lead, percentchange, moving, upto,
        basecall,
-       merge, collapse,
+       merge, collapse, merge1,
        readtimearray
 
 ###### include ##################

--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -16,7 +16,7 @@ export TimeArray, AbstractTimeSeries,
        by, from, to, findwhen, findall, timestamp, values, colnames, 
        lag, lead, percentchange, moving, upto,
        basecall,
-       merge, collapse, merge1,
+       merge, collapse, merge1, merge2, overlaps, # don't export overlaps after troubleshooting
        readtimearray
 
 ###### include ##################

--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -16,7 +16,7 @@ export TimeArray, AbstractTimeSeries,
        by, from, to, findwhen, findall, timestamp, values, colnames, 
        lag, lead, percentchange, moving, upto,
        basecall,
-       merge, collapse, merge1, merge2, overlaps, # don't export overlaps after troubleshooting
+       merge, collapse,
        readtimearray
 
 ###### include ##################

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -45,6 +45,26 @@ function merge{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; colnames = [""], method=
     TimeArray(newshorter.timestamp, vals, cnames, meta)
 end
 
+function merge1{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; col_names=[""], method="inner")
+    # start with array of Date
+    tstamp = intersect(ta1.timestamp, ta2.timestamp)
+    # get array of Ints
+    tt1    = findin(ta1.timestamp, tstamp)
+    tt2    = findin(ta2.timestamp, tstamp)
+    # retrieve values that match the Int array matching dates
+    vals1  = ta1[tt1].values
+    vals2  = ta2[tt2].values
+    # combine the values arrays
+    vals   = hcat(vals1,vals2)
+    # combine existing colnames
+    cnames = vcat(ta1.colnames, ta2.colnames)
+    # check if kwarg to over-ride simple vcat and then if colnames is valid length
+    size(col_names,1) == 1 ? cnames = cnames :       # kwarg not supplied
+    size(col_names,1) == size(vals,2) ? cnames = col_names : error("col_names supplied is not correct size")
+    # put it all together
+    TimeArray(tstamp, vals, cnames)
+end
+
 # collapse ######################
 
 function collapse{T,N}(ta::TimeArray{T,N}, f::Function; period::Function=week)

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -77,3 +77,37 @@ facts("merge1 works correctly") do
         @fact merge1(op[2:5], cl).colnames[2]  => "Close"
     end
 end
+
+facts("merge2 works correctly") do
+
+    context("takes colnames kwarg correctly") do
+        @fact merge2(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] => "a"
+        @fact merge2(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] => "b"
+        @fact merge2(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] => "c"
+        @fact merge2(cl,op, col_names=["a","b"]).colnames[1]                      => "a"
+        @fact merge2(cl,op, col_names=["a","b"]).colnames[2]                      => "b"
+        @fact merge2(cl,op, col_names=["a"]).colnames[1]                          => "Close"
+        @fact merge2(cl,op, col_names=["a"]).colnames[2]                          => "Open"
+        @fact_throws merge2(cl,op, col_names=["a","b","c"])
+        @fact_throws merge2(cl,op, col_names=["a","b","c"])
+    end
+  
+    context("returns correct alignment with Dates and values") do
+        @fact merge2(cl,op).values[2,1] => cl.values[2,1]
+        @fact merge2(cl,op).values[2,2] => op.values[2,1]
+    end
+    
+    context("aligns with disparate sized objects") do
+        @fact merge2(cl, op[2:5]).values[1,1]  => cl.values[2,1]
+        @fact merge2(cl, op[2:5]).values[1,2]  => op.values[2,1]
+        @fact merge2(cl, op[2:5]).timestamp[1] => Date(2000,1,4)
+        @fact length(merge2(cl, op[2:5]))      => 4
+    end
+
+    context("column names match the correct values") do
+        @fact merge2(cl, op[2:5]).colnames[1]  => "Close"
+        @fact merge2(cl, op[2:5]).colnames[2]  => "Open"
+        @fact merge2(op[2:5], cl).colnames[1]  => "Open"
+        @fact merge2(op[2:5], cl).colnames[2]  => "Close"
+    end
+end

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -43,3 +43,37 @@ facts("merge works correctly") do
         @fact merge(op[2:5], cl).colnames[2]  => "Close"
     end
 end
+
+facts("merge1 works correctly") do
+
+    context("takes colnames kwarg correctly") do
+        @fact merge1(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] => "a"
+        @fact merge1(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] => "b"
+        @fact merge1(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] => "c"
+        @fact merge1(cl,op, col_names=["a","b"]).colnames[1]                      => "a"
+        @fact merge1(cl,op, col_names=["a","b"]).colnames[2]                      => "b"
+        @fact merge1(cl,op, col_names=["a"]).colnames[1]                          => "Close"
+        @fact merge1(cl,op, col_names=["a"]).colnames[2]                          => "Open"
+        @fact_throws merge1(cl,op, col_names=["a","b","c"])
+        @fact_throws merge1(cl,op, col_names=["a","b","c"])
+    end
+  
+    context("returns correct alignment with Dates and values") do
+        @fact merge1(cl,op).values[2,1] => cl.values[2,1]
+        @fact merge1(cl,op).values[2,2] => op.values[2,1]
+    end
+    
+    context("aligns with disparate sized objects") do
+        @fact merge1(cl, op[2:5]).values[1,1]  => cl.values[2,1]
+        @fact merge1(cl, op[2:5]).values[1,2]  => op.values[2,1]
+        @fact merge1(cl, op[2:5]).timestamp[1] => Date(2000,1,4)
+        @fact length(merge1(cl, op[2:5]))      => 4
+    end
+
+    context("column names match the correct values") do
+        @fact merge1(cl, op[2:5]).colnames[1]  => "Close"
+        @fact merge1(cl, op[2:5]).colnames[2]  => "Open"
+        @fact merge1(op[2:5], cl).colnames[1]  => "Open"
+        @fact merge1(op[2:5], cl).colnames[2]  => "Close"
+    end
+end

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -13,15 +13,15 @@ end
 facts("merge works correctly") do
 
     context("takes colnames kwarg correctly") do
-        @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[1] => "a"
-        @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[2] => "b"
-        @fact merge(cl,ohlc["High", "Low"], colnames=["a","b","c"]).colnames[3] => "c"
-        @fact merge(cl,op, colnames=["a","b"]).colnames[1]                      => "a"
-        @fact merge(cl,op, colnames=["a","b"]).colnames[2]                      => "b"
-        @fact merge(cl,op, colnames=["a"]).colnames[1]                          => "Close"
-        @fact merge(cl,op, colnames=["a"]).colnames[2]                          => "Open"
-        @fact_throws merge(cl,op, colnames=["a","b","c"])
-        @fact_throws merge(cl,op, colnames=["a","b","c"])
+        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] => "a"
+        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] => "b"
+        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] => "c"
+        @fact merge(cl,op, col_names=["a","b"]).colnames[1]                      => "a"
+        @fact merge(cl,op, col_names=["a","b"]).colnames[2]                      => "b"
+        @fact merge(cl,op, col_names=["a"]).colnames[1]                          => "Close"
+        @fact merge(cl,op, col_names=["a"]).colnames[2]                          => "Open"
+        @fact_throws merge(cl,op, col_names=["a","b","c"])
+        @fact_throws merge(cl,op, col_names=["a","b","c"])
     end
   
     context("returns correct alignment with Dates and values") do
@@ -41,73 +41,5 @@ facts("merge works correctly") do
         @fact merge(cl, op[2:5]).colnames[2]  => "Open"
         @fact merge(op[2:5], cl).colnames[1]  => "Open"
         @fact merge(op[2:5], cl).colnames[2]  => "Close"
-    end
-end
-
-facts("merge1 works correctly") do
-
-    context("takes colnames kwarg correctly") do
-        @fact merge1(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] => "a"
-        @fact merge1(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] => "b"
-        @fact merge1(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] => "c"
-        @fact merge1(cl,op, col_names=["a","b"]).colnames[1]                      => "a"
-        @fact merge1(cl,op, col_names=["a","b"]).colnames[2]                      => "b"
-        @fact merge1(cl,op, col_names=["a"]).colnames[1]                          => "Close"
-        @fact merge1(cl,op, col_names=["a"]).colnames[2]                          => "Open"
-        @fact_throws merge1(cl,op, col_names=["a","b","c"])
-        @fact_throws merge1(cl,op, col_names=["a","b","c"])
-    end
-  
-    context("returns correct alignment with Dates and values") do
-        @fact merge1(cl,op).values[2,1] => cl.values[2,1]
-        @fact merge1(cl,op).values[2,2] => op.values[2,1]
-    end
-    
-    context("aligns with disparate sized objects") do
-        @fact merge1(cl, op[2:5]).values[1,1]  => cl.values[2,1]
-        @fact merge1(cl, op[2:5]).values[1,2]  => op.values[2,1]
-        @fact merge1(cl, op[2:5]).timestamp[1] => Date(2000,1,4)
-        @fact length(merge1(cl, op[2:5]))      => 4
-    end
-
-    context("column names match the correct values") do
-        @fact merge1(cl, op[2:5]).colnames[1]  => "Close"
-        @fact merge1(cl, op[2:5]).colnames[2]  => "Open"
-        @fact merge1(op[2:5], cl).colnames[1]  => "Open"
-        @fact merge1(op[2:5], cl).colnames[2]  => "Close"
-    end
-end
-
-facts("merge2 works correctly") do
-
-    context("takes colnames kwarg correctly") do
-        @fact merge2(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] => "a"
-        @fact merge2(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] => "b"
-        @fact merge2(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] => "c"
-        @fact merge2(cl,op, col_names=["a","b"]).colnames[1]                      => "a"
-        @fact merge2(cl,op, col_names=["a","b"]).colnames[2]                      => "b"
-        @fact merge2(cl,op, col_names=["a"]).colnames[1]                          => "Close"
-        @fact merge2(cl,op, col_names=["a"]).colnames[2]                          => "Open"
-        @fact_throws merge2(cl,op, col_names=["a","b","c"])
-        @fact_throws merge2(cl,op, col_names=["a","b","c"])
-    end
-  
-    context("returns correct alignment with Dates and values") do
-        @fact merge2(cl,op).values[2,1] => cl.values[2,1]
-        @fact merge2(cl,op).values[2,2] => op.values[2,1]
-    end
-    
-    context("aligns with disparate sized objects") do
-        @fact merge2(cl, op[2:5]).values[1,1]  => cl.values[2,1]
-        @fact merge2(cl, op[2:5]).values[1,2]  => op.values[2,1]
-        @fact merge2(cl, op[2:5]).timestamp[1] => Date(2000,1,4)
-        @fact length(merge2(cl, op[2:5]))      => 4
-    end
-
-    context("column names match the correct values") do
-        @fact merge2(cl, op[2:5]).colnames[1]  => "Close"
-        @fact merge2(cl, op[2:5]).colnames[2]  => "Open"
-        @fact merge2(op[2:5], cl).colnames[1]  => "Open"
-        @fact merge2(op[2:5], cl).colnames[2]  => "Close"
     end
 end


### PR DESCRIPTION
The new `merge1` (designed to replace the current `merge`) has about a quarter of the lines of code (40 -> 10) and runs faster.

````julia
julia> @elapsed merge(AAPL,BA)
0.608618657

julia> @elapsed merge(AAPL,BA)
0.465285163

julia> @elapsed merge(AAPL,BA)
0.471265437

# now for merge1

julia> @elapsed merge1(AAPL,BA)
0.121858314

julia> @elapsed merge1(AAPL,BA)
0.106935782

julia> @elapsed merge1(AAPL,BA)
0.116042072
````
That's about 4-5x speed improvement!