### PR TITLE
Math/comparison/logic operation refactoring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * changed references of float(x) to map(Float64, x)
 * changed references of [a] to [a;] in a comprehension found in the by() method
 * added Compat package
-* substantial speedup for eleemnt-wise mathematical operators
+* substantial speedup for element-wise mathematical operators
 
 ### 0.5.9
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,128 +1,126 @@
-MATH_ALL        = [:.+, :.-, :.*, :./, :.^, :+, :-, :*, :/, :^]
-MATH_DOTONLY    = [:.+, :.-, :.*, :./]
-COMPARE_DOTONLY = [:.>, :.<, :.==, :.>=, :.<=] 
+UNARY         = [:+, :-, :!]
+MATH_NO_DOT   = [:+, :-, :*, :/, :^, :%]
+MATH_DOT      = [:.+, :.-, :.*, :./, :.^, :.%]
+COMPARISONS   = [:.>,:.<, :.==, :.>=, :.<=, :.!=]
+LOGICAL       = [:&, :|, :$]
 
-###### Mathematical operators  ###############
+SCALAR_OPS    = [MATH_NO_DOT; MATH_DOT; COMPARISONS]
+ELEMENT_OPS   = [MATH_DOT; COMPARISONS]
+BOOLEAN_OPS   = [LOGICAL; COMPARISONS]
 
-# TimeArray <--> TimeArray 
-for op in MATH_DOTONLY
+###### Math and Boolean Unary Operators  #####
+
+for op in UNARY
   @eval begin
-    function ($op){T,N}(ta1::TimeArray{T,N}, ta2::TimeArray{T,N})
+    function ($op){T,N}(ta::TimeArray{T,N})
+      cnames  = [string($op) * name for name in ta.colnames]
+      basecall(ta, ($op), cnames=cnames) 
+    end # function
+  end # eval
+end # loop
+
+###### Numerical Operations and Comparisons ########
+
+# TimeArray <--> Scalar 
+for op in SCALAR_OPS 
+  @eval begin
+    function ($op){T,N}(ta::TimeArray{T,N}, var::Union(BigInt,Signed,Unsigned,FloatingPoint))
+      cnames  = [name * string($op) * string(var) for name in ta.colnames]
+      vals = ($op)(ta.values, var)
+      TimeArray(ta.timestamp, vals, cnames, ta.meta)
+    end # function
+  end # eval
+end # loop
+
+# Scalar <--> TimeArray
+for op in SCALAR_OPS 
+  @eval begin
+    function ($op){T,N}(var::Union(BigInt,Signed,Unsigned,FloatingPoint), ta::TimeArray{T,N})
+      cnames  = [string(var) * string($op) * name for name in ta.colnames]
+      vals = ($op)(var, ta.values)
+      TimeArray(ta.timestamp, vals, cnames, ta.meta)
+    end # function
+  end # eval
+end # loop
+
+# ND TimeArray <--> MD TimeArray
+for op in ELEMENT_OPS 
+  @eval begin
+    function ($op){T,N,M}(ta1::TimeArray{T,N}, ta2::TimeArray{T,M})
       # first test metadata matches
-      ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
-      cname  = [ta1.colnames[1][1:2] *  string($op) *  ta2.colnames[1][1:2]]
+      ta1.meta == ta2.meta ?
+        meta = ta1.meta :
+        error("metadata doesn't match")
+      # determine array widths and name cols accordingly
+      w1 = length(ta1.colnames)
+      w2 = length(ta2.colnames)
+      if w1 == w2 
+        cnames = [ta1.colnames[i]*string($op)*ta2.colnames[i] for i=1:w1]
+      elseif w1==1
+        cnames = [ta1.colnames[1]*string($op)*ta2.colnames[i] for i=1:w2]
+      elseif w2==1
+        cnames = [ta1.colnames[i]*string($op)*ta2.colnames[1] for i=1:w1]
+      else
+        error("arrays must have the same number of columns, or one must be a single column")
+      end
+      # obtain shared timestamp
+      idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
+      tstamp = ta1[idx1].timestamp
+      # retrieve values that match the Int array matching dates
+      vals1  = ta1[idx1].values
+      vals2  = ta2[idx2].values
+      # compute output values
+      vals = ($op)(vals1, vals2)
+      TimeArray(tstamp, vals, cnames, meta)
+    end # function
+  end # eval
+end # loop
+
+###### Boolean Operations and Comparisons ###########
+
+# TimeArray <--> Bool 
+for op in BOOLEAN_OPS 
+  @eval begin
+    function ($op){N}(ta::TimeArray{Bool,N}, var::Bool)
+      cnames = [name * string($op) * string(var) for name in ta.colnames]
+      vals   = ($op)(ta.values, var)
+      TimeArray(ta.timestamp, vals, cnames, ta.meta)
+    end # function
+  end # eval
+end # loop
+
+# Bool <--> TimeArray
+for op in BOOLEAN_OPS 
+  @eval begin
+    function ($op){N}(var::Bool, ta::TimeArray{Bool,N})
+      cnames = [string(var) * string($op) * name for name in ta.colnames]
+      vals   = ($op)(var, ta.values)
+      TimeArray(ta.timestamp, vals, cnames, ta.meta)
+    end # function
+  end # eval
+end # loop
+
+# Boolean ND TimeArray <--> Boolean ND TimeArray
+for op in BOOLEAN_OPS 
+  @eval begin
+    function ($op){N}(ta1::TimeArray{Bool,N}, ta2::TimeArray{Bool,N})
+      # test column count matches
+      length(ta1.colnames) == length(ta2.colnames) ?
+        ncols=length(ta1.colnames) :
+        error("arrays must have the same number of columns")
+      # test metadata matches
+      ta1.meta == ta2.meta ?
+        meta = ta1.meta :
+        error("metadata doesn't match")
+      cnames = [ta1.colnames[i]*string($op)*ta2.colnames[i] for i=1:ncols]
       idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
       # obtain shared timestamp
       tstamp = ta1[idx1].timestamp
       # retrieve values that match the Int array matching dates
       vals1  = ta1[idx1].values
       vals2  = ta2[idx2].values
-      vals = Array(T, length(idx1))
-      for i in 1:length(vals)
-        vals[i] = ($op)(vals1[i], vals2[i])
-      end
-      TimeArray(tstamp, vals, cname, meta)
-    end # function
-  end # eval
-end # loop
-
-# TimeArray (2d) <--> TimeArray (1d)
-for op in MATH_DOTONLY
-  @eval begin
-    function ($op){T}(ta1::TimeArray{T,2}, ta2::TimeArray{T,1})
-       # first test metadata matches
-       ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
-       # interate to find when there is a match on timestamp
-       counter = Int[]
-       for i in 1:length(ta1)
-           if in(ta1[i].timestamp[1], ta2.timestamp)
-               push!(counter, i)
-           end
-       end
-       # create new shortened versions of ta1 and ta2
-       newta1 = ta1[counter]
-       newta2 = ta2[newta1.timestamp]
-
-       # operate on the values columns
-       vals = ($op)(ta1.values, ta2.values) 
-
-       cnames = repmat([""], length(ta1.colnames))
-       for i in 1:length(ta1.colnames)
-           cnames[i] = string(ta1.colnames[i])[1:2] * " " *  string($op) * " " *  string(ta2.colnames[1])[1:2]
-       end
-       TimeArray(newta1.timestamp, vals, cnames, meta)
-    end # function
-  end # eval
-end # loop
-
-# TimeArray <--> Int,Float64
-for op in MATH_ALL
-  @eval begin
-    function ($op){T,N}(ta::TimeArray{T,N}, var::Union(Int,Float64))
-      vals = ($op)([t for t in ta.values], var)
-      TimeArray(ta.timestamp, vals, ta.colnames, ta.meta)
-    end # function
-  end # eval
-end # loop
-
-# element-wise mathematical operations between an Int,Float64 and column
-for op in MATH_ALL
-  @eval begin
-    function ($op){T,N}(var::Union(Int,Float64), ta::TimeArray{T,N})
-      vals = ($op)(var, [t for t in ta.values])
-      TimeArray(ta.timestamp, vals, ta.colnames, ta.meta)
-    end # function
-  end # eval
-end # loop
-
-###### Comparison operators  ###############
-
-# TimeArray <--> TimeArray 
-for op in COMPARE_DOTONLY 
-  @eval begin
-    function ($op){T,N}(ta1::TimeArray{T,N}, ta2::TimeArray{T,N})
-      # first test metadata matches
-      ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
-      cname  = [ta1.colnames[1][1:2] *  string($op) *  ta2.colnames[1][1:2]]
-      idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
-      # obtain shared timestamp
-      tstamp = ta1[idx1].timestamp
-      # retrieve values that match the Int array matching dates
-      vals1  = ta1[idx1].values
-      vals2  = ta2[idx2].values
-      vals = Array(Bool, length(idx1))
-      for i in 1:length(vals)
-        vals[i] = ($op)(vals1[i], vals2[i])
-      end
-      TimeArray(tstamp, vals, cname, meta)
-    end # function
-  end # eval
-end # loop
-
-# TimeArray <--> Int,Float64
-for op in COMPARE_DOTONLY 
-  @eval begin
-    function ($op){T,N}(ta::TimeArray{T,N}, var::Union(Int,Float64))
-      cname  = [ta.colnames[1][1:2] *  string($op) *  string(var)]
-      vals   = Array(Bool, length(ta))
-      for i in 1:length(vals)
-        vals[i] = ($op)(ta.values[i], var) 
-      end
-      TimeArray(ta.timestamp, vals, cname, ta.meta)
-    end # function
-  end # eval
-end # loop
-
-# Int,Float64 <--> TimeArray
-for op in COMPARE_DOTONLY 
-  @eval begin
-    function ($op){T,N}(var::Union(Int,Float64), ta::TimeArray{T,N})
-      cname  = [ta.colnames[1][1:2] *  string($op) *  string(var)]
-      vals   = Array(Bool, length(ta))
-      for i in 1:length(vals)
-        vals[i] = ($op)(var, ta.values[i])
-      end
-      TimeArray(ta.timestamp, vals, cname, ta.meta)
+      vals = ($op)(vals1, vals2)
+      TimeArray(tstamp, vals, cnames, meta)
     end # function
   end # eval
 end # loop

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -7,12 +7,12 @@ abstract AbstractTimeSeries
 immutable TimeArray{T,N,M} <: AbstractTimeSeries
 
     timestamp::Union(Vector{Date}, Vector{DateTime})
-    values::Array{T,N}
+    values::DenseArray{T,N}
     colnames::Vector{UTF8String}
     meta::M
 
     function TimeArray(timestamp::Union(Vector{Date}, Vector{DateTime}),
-                       values::Array{T,N}, 
+                       values::DenseArray{T,N}, 
                        colnames::Vector{UTF8String},
                        meta::M)
                            nrow, ncol = size(values, 1), size(values, 2)
@@ -26,12 +26,12 @@ immutable TimeArray{T,N,M} <: AbstractTimeSeries
     end
 end
 
-TimeArray{T,N,S<:String,M}(d::Union(Vector{Date}, Vector{DateTime}), v::Array{T,N}, c::Vector{S}, m::M) = TimeArray{T,N,M}(d,v,map(utf8,c),m)
-TimeArray{T,N,S<:String,M}(d::Union(Date, DateTime), v::Array{T,N}, c::Array{S,1}, m::M) = TimeArray([d],v,map(utf8,c),m)
+TimeArray{T,N,S<:String,M}(d::Union(Vector{Date}, Vector{DateTime}), v::DenseArray{T,N}, c::Vector{S}, m::M) = TimeArray{T,N,M}(d,v,map(utf8,c),m)
+TimeArray{T,N,S<:String,M}(d::Union(Date, DateTime), v::DenseArray{T,N}, c::Array{S,1}, m::M) = TimeArray([d],v,map(utf8,c),m)
 
 # when no meta is provided
-TimeArray{T,N}(d::Union(Vector{Date}, Vector{DateTime}), v::Array{T,N}, c) = TimeArray(d,v,c,Nothing)
-TimeArray{T,N}(d::Union(Date, DateTime), v::Array{T,N}, c) = TimeArray([d],v,c,Nothing)
+TimeArray{T,N}(d::Union(Vector{Date}, Vector{DateTime}), v::DenseArray{T,N}, c) = TimeArray(d,v,c,Nothing)
+TimeArray{T,N}(d::Union(Date, DateTime), v::DenseArray{T,N}, c) = TimeArray([d],v,c,Nothing)
 
 ###### conversion ###############
 

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -67,13 +67,6 @@ end
 
 facts("base element-wise operators on TimeArray values") do
 
-  context("correct alignment and operation between two TimeVectors") do
-     @fact (cl .+ op).values[1]           => roughly(216.82)
-     @fact (cl .- op).values[1]           => roughly(7.06)
-     @fact (cl .* op).values[1]           => roughly(11740.27)
-     @fact (cl ./ op).values[1]           => roughly(1.067315)
-  end
-
   context("only values on intersecting Dates computed") do
      @fact (cl[1:2] ./ op[2:3]).values[1] => roughly(0.946882) 
      @fact (cl[1:4] .+ op[4:7]).values[1] => roughly(201.12)
@@ -81,49 +74,100 @@ facts("base element-wise operators on TimeArray values") do
      @fact length(cl[1:4] .+ op[4:7])     => 1
   end
 
-  context("correct dot operation between TimeVectors values and Int/Float64 and viceversa") do
+  context("correct unary operation on TimeArray values") do
+     @fact (+cl).values[1]  => cl.values[1]
+     @fact (-cl).values[1]  => -cl.values[1]
+     @fact (!(cl .== op)).values[1]  => true
+     @fact (+ohlc).values[1,:]  => ohlc.values[1,:]
+     @fact (-ohlc).values[1,:]  => -(ohlc.values[1,:])
+     @fact (!(ohlc .== ohlc)).values[1,:]  => [false false false false]
+  end
+
+  context("correct non-dot operation between TimeArray values and Int/Float64 and viceversa") do
+     @fact (cl - 100).values[1] => roughly(11.94)
+     @fact (cl + 100).values[1] => roughly(211.94)
+     @fact (cl * 100).values[1] => roughly(11194)
+     @fact (cl / 100).values[1] => roughly(1.1194)
+     @fact (cl % 2).values[1]   =>  cl.values[1] % 2
+     @pending (cl ^ 2).values[1]   => roughly(12530.5636)
+     @fact (100 - cl).values[1] => roughly(-11.94)
+     @fact (100 + cl).values[1] => roughly(211.94)
+     @fact (100 * cl).values[1] => roughly(11194)
+     @fact_throws (100 / cl).values[1] # related to base not supporting this
+     @fact_throws (2 ^ cl).values[1] # base doesn't support this either
+     @fact (2 % cl).values[1] => 2 % cl.values[1]
+     @fact (ohlc - 100).values[1,:] => ohlc.values[1,:] - 100
+     @fact (ohlc + 100).values[1,:] => ohlc.values[1,:] + 100
+     @fact (ohlc * 100).values[1,:] => ohlc.values[1,:] * 100
+     @fact (ohlc / 100).values[1,:] => ohlc.values[1,:] / 100
+     @pending (ohlc ^ 2).values[1,:]   => ohlc.values[1,:] ^ 2
+     @fact (ohlc % 2).values[1,:] => ohlc.values[1,:] % 2
+     @fact (100 - ohlc).values[1,:] => 100 - ohlc.values[1,:]
+     @fact (100 + ohlc).values[1,:] => 100 + ohlc.values[1,:]
+     @fact (100 * ohlc).values[1,:] => 100 * ohlc.values[1,:]
+     @fact_throws (100 / ohlc).values[1,:] # related to base not supporting this
+     @fact_throws (2 ^ ohlc).values[1,:] # base doesn't support this either
+     @fact (2 % ohlc).values[1,:] => 2 % ohlc.values[1,:]
+  end
+
+  context("correct dot operation between TimeArray values and Int/Float64 and viceversa") do
      @fact (cl .- 100).values[1] => roughly(11.94)
      @fact (cl .+ 100).values[1] => roughly(211.94)
      @fact (cl .* 100).values[1] => roughly(11194)
      @fact (cl ./ 100).values[1] => roughly(1.1194)
      @fact (cl .^ 2).values[1]   => roughly(12530.5636)
+     @fact (cl .% 2).values[1]   => cl.values[1] .% 2
      @fact (100 .- cl).values[1] => roughly(-11.94)
      @fact (100 .+ cl).values[1] => roughly(211.94)
      @fact (100 .* cl).values[1] => roughly(11194)
      @fact (100 ./ cl).values[1] => roughly(0.8933357155619082)
      @fact (2 .^ cl).values[1]   => 4980784073277740581384811358191616
+     @fact (2 .% cl).values[1]   => 2
+     @fact (ohlc .- 100).values[1,:] => ohlc.values[1,:] .- 100
+     @fact (ohlc .+ 100).values[1,:] => ohlc.values[1,:] .+ 100
+     @fact (ohlc .* 100).values[1,:] => ohlc.values[1,:] .* 100
+     @fact (ohlc ./ 100).values[1,:] => ohlc.values[1,:] ./ 100
+     @fact (ohlc .^ 2).values[1,:]   => ohlc.values[1,:] .^ 2
+     @fact (ohlc .% 2).values[1,:]   => ohlc.values[1,:] .% 2
+     @fact (100 .- ohlc).values[1,:] => 100 .- ohlc.values[1,:]
+     @fact (100 .+ ohlc).values[1,:] => 100 .+ ohlc.values[1,:]
+     @fact (100 .* ohlc).values[1,:] => 100 .* ohlc.values[1,:]
+     @fact (100 ./ ohlc).values[1,:] => 100 ./ ohlc.values[1,:]
+     @fact (2 .^ ohlc).values[1,:]   => 2 .^ ohlc.values[1,:]
+     @fact (2 .% ohlc).values[1,:]   => 2 .% ohlc.values[1,:]
+  end
+
+  context("correct alignment and operation between two TimeArrays") do
+     @fact (cl .+ op).values[1]      => roughly(216.82)
+     @fact (cl .- op).values[1]      => roughly(7.06)
+     @fact (cl .* op).values[1]      => roughly(11740.27)
+     @fact (cl ./ op).values[1]      => roughly(1.067315)
+     @fact (cl .% op).values         => cl.values .% op.values
+     @fact (cl .^ op).values         => cl.values .^ op.values
+     @fact (ohlc .+ ohlc).values     => ohlc.values .+ ohlc.values
+     @fact (ohlc .- ohlc).values     => ohlc.values .- ohlc.values
+     @fact (ohlc .* ohlc).values     => ohlc.values .* ohlc.values
+     @fact (ohlc ./ ohlc).values     => ohlc.values ./ ohlc.values
+     @fact (ohlc .% ohlc).values     => ohlc.values .% ohlc.values
+     @fact (ohlc .^ ohlc).values     => ohlc.values .^ ohlc.values
   end
 
   context("element-wise mathematical operations between 2d time array and 1d time array") do
-     @fact (ohlc .+ cl).values[1,1] => roughly(216.82)
-     @fact (ohlc .+ cl).values[1,2] => roughly(224.44)
-     @fact (ohlc .* cl).values[1,1] => roughly(11740.27)
-     @fact (ohlc .* cl).values[1,2] => roughly(12593.25)
+     @fact (ohlc .+ cl).values => ohlc.values .+ cl.values
+     @fact (ohlc .- cl).values => ohlc.values .- cl.values
+     @fact (ohlc .* cl).values => ohlc.values .* cl.values
+     @fact (ohlc ./ cl).values => ohlc.values ./ cl.values
+     @fact (ohlc .% cl).values => ohlc.values .% cl.values
+     @fact (ohlc .^ cl).values => ohlc.values .^ cl.values
+     @fact (cl .+ ohlc).values => cl.values .+ ohlc.values
+     @fact (cl .- ohlc).values => cl.values .- ohlc.values
+     @fact (cl .* ohlc).values => cl.values .* ohlc.values
+     @fact (cl ./ ohlc).values => cl.values ./ ohlc.values
+     @fact (cl .% ohlc).values => cl.values .% ohlc.values
+     @fact (cl .^ ohlc).values => cl.values .^ ohlc.values
   end
 
-  context("correct non-dot operation between TimeVectors values and Int/Float64 and viceversa") do
-     @fact (cl - 100).values[1] => roughly(11.94)
-     @fact (cl + 100).values[1] => roughly(211.94)
-     @fact (cl * 100).values[1] => roughly(11194)
-     @fact (cl / 100).values[1] => roughly(1.1194)
-     @pending (cl ^ 2).values[1]   => roughly(12530.5636)
-     @fact (100 - cl).values[1] => roughly(-11.94)
-     @fact (100 + cl).values[1] => roughly(211.94)
-     @fact (100 * cl).values[1] => roughly(11194)
-     #@fact (100 / cl).values[1] => roughly(0.8933357155619082)
-     @fact_throws (100 / cl).values[1] # related to base not supporting this 
-     @pending (2 ^ cl).values[1]   => 4980784073277740581384811358191616
-  end
-
-  context("correct operation between two TimeVectors values returns bool for comparisons") do
-     @fact (cl .> op).values[1]  => true
-     @fact (cl .< op).values[1]  => false
-     @fact (cl .<= op).values[1] => false
-     @fact (cl .>= op).values[1] => true
-     @fact (cl .== op).values[1] => false
-  end
-
-  context("correct operation between TimeVectors values and Int/Float64 (and viceversa) returns bool for comparison") do
+  context("correct operation between TimeArray values and Int/Float64 (and viceversa) returns bool for comparison") do
      @fact (cl .> 111.94).values[1]  => false
      @fact (cl .< 111.94).values[1]  => false
      @fact (cl .>= 111.94).values[1] => true
@@ -134,7 +178,74 @@ facts("base element-wise operators on TimeArray values") do
      @fact (111.94 .>= cl).values[1] => true
      @fact (111.94 .<= cl).values[1] => true
      @fact (111.94 .== cl).values[1] => true
+     @fact (ohlc .> 111.94).values[1,:]  => [false true false false]
+     @fact (ohlc .< 111.94).values[1,:]  => [true false true false]
+     @fact (ohlc .>= 111.94).values[1,:] => [false true false true]
+     @fact (ohlc .<= 111.94).values[1,:] => [true false true true]
+     @fact (ohlc .== 111.94).values[1,:] => [false false false true]
+     @fact (ohlc .!= 111.94).values[1,:] => [true true true false]
+     @fact (111.94 .> ohlc).values[1,:]  => [true false true false]
+     @fact (111.94 .< ohlc).values[1,:]  => [false true false false]
+     @fact (111.94 .>= ohlc).values[1,:] => [true false true true]
+     @fact (111.94 .<= ohlc).values[1,:] => [false true false true]
+     @fact (111.94 .== ohlc).values[1,:] => [false false false true]
+     @fact (111.94 .!= ohlc).values[1,:] => [true true true false]
   end
+
+  context("correct operation between two TimeArray values returns bool for comparisons") do
+     @fact (cl .> op).values[1]  => true
+     @fact (cl .< op).values[1]  => false
+     @fact (cl .<= op).values[1] => false
+     @fact (cl .>= op).values[1] => true
+     @fact (cl .== op).values[1] => false
+     @fact (cl .!= op).values[1] => true
+     @fact (ohlc .> ohlc).values[1,:]  => [false false false false]
+     @fact (ohlc .< ohlc).values[1,:]  => [false false false false]
+     @fact (ohlc .<= ohlc).values[1,:] => [true true true true]
+     @fact (ohlc .>= ohlc).values[1,:] => [true true true true]
+     @fact (ohlc .== ohlc).values[1,:] => [true true true true]
+     @fact (ohlc .!= ohlc).values[1,:] => [false false false false]
+  end
+
+  context("element-wise comparison operations between 2d time array and 1d time array") do
+     @fact (ohlc .> cl).values  => ohlc.values .> cl.values
+     @fact (ohlc .< cl).values  => ohlc.values .< cl.values
+     @fact (ohlc .>= cl).values => ohlc.values .>= cl.values
+     @fact (ohlc .<= cl).values => ohlc.values .<= cl.values
+     @fact (ohlc .== cl).values => ohlc.values .== cl.values
+     @fact (ohlc .!= cl).values => ohlc.values .!= cl.values
+     @fact (cl .> ohlc).values  => cl.values .> ohlc.values
+     @fact (cl .< ohlc).values  => cl.values .< ohlc.values
+     @fact (cl .>= ohlc).values => cl.values .>= ohlc.values
+     @fact (cl .<= ohlc).values => cl.values .<= ohlc.values
+     @fact (cl .== ohlc).values => cl.values .== ohlc.values
+     @fact (cl .!= ohlc).values => cl.values .!= ohlc.values
+  end
+
+  context("correct bitwise elementwise operations between bool and TimeArrays' values") do
+     @fact ((cl .> 100) & true).values[1] => true
+     @fact (false & (cl .> 100)).values[1] => false
+     @fact ((cl .> 100) | true).values[1] => true
+     @fact (false | (cl .> 100)).values[1] => true
+     @fact ((cl .> 100) $ true).values[1] => false
+     @fact (false $ (cl .> 100)).values[1] => true
+     @fact ((ohlc .> 100) & true).values[4,:] => [true true false false]
+     @fact (false & (ohlc .> 100)).values[4,:] => [false false false false]
+     @fact ((ohlc .> 100) | true).values[4,:] => [true true true true]
+     @fact (false | (ohlc .> 100)).values[4,:] => [true true false false]
+     @fact ((ohlc .> 100) $ true).values[4,:] => [false false true true]
+     @fact (false $ (ohlc .> 100)).values[4,:] => [true true false false]
+  end
+
+  context("correct bitwise elementwise operations between same-dimensioned TimeArrays' boolean values") do
+     @fact ((cl .> 100) & (cl .< 120)).values[1] => true
+     @fact ((cl .> 100) | (cl .< 120)).values[1] => true
+     @fact ((cl .> 100) $ (cl .< 120)).values[1] => false
+     @fact ((ohlc .> 100) & (ohlc .< 120)).values[4,:] => [true true false false]
+     @fact ((ohlc .> 100) | (ohlc .< 120)).values[4,:] => [true true true true]
+     @fact ((ohlc .> 100) $ (ohlc .< 120)).values[4,:] => [false false true true]
+  end
+
 end
 
 facts("basecall works with Base methods") do


### PR DESCRIPTION
This refactors TimeArray math, comparison, and logic operations to be wrappers for base operations on the underlying value arrays - automatically aligning functionality with standard Array operations as defined by `Base` and saving some LOC.  Also adds symmetric functionality for broadcasting (2D __ 1D -> 2D, and 1D _ 2D -> 2D), elementwise `.^`, `.!=`, `%`, `.%`, unary math and logic operators (`!`, `+`, `-`) and binary logic operators (`&`, `|`, `$`), which allow things like:

```julia
julia> using MarketData

julia> (ohlc["Close"] .> 100) & (ohlc["Close"] .< 120)
500x1 TimeArray{Bool,1,DataType} 2000-01-03 to 2001-12-31

             Close.>100&Close.<120  
2000-01-03 | true                   
2000-01-04 | true                   
2000-01-05 | true                   
2000-01-06 | false                  
⋮
2001-12-26 | false                  
2001-12-27 | false                  
2001-12-28 | false                  
2001-12-31 | false
```
I took the liberty of changing the `TimeArray.values` type from `Array{T}` to `DenseArray{T}` (https://github.com/JuliaStats/TimeSeries.jl/issues/194) to accommodate BitArrays and implement the boolean operators... But I'm happy to go with a workaround if the preference is not to generalize the type.

Also, while `Base` implements bitwise operations on numbers and math operations on booleans, I thought that given the typical application context here that functionality would likely cause more bugs from user typos than provide benefits, and so left those out.