### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,6 +1,10 @@
-MATH_ALL        = [:.+, :.-, :.*, :./, :.^, :+, :-, :*, :/, :^]
-MATH_DOTONLY    = [:.+, :.-, :.*, :./]
+MATH_DOTONLY    = [:.+, :.-, :.*, :./, :.^]
+MATH_ALL        = [MATH_DOTONLY; [:+, :-, :*, :/, :^]]
 COMPARE_DOTONLY = [:.>, :.<, :.==, :.>=, :.<=] 
+
+for op in [MATH_ALL; COMPARE_DOTONLY]
+  @eval import Base.$op
+end # for
 
 ###### Mathematical operators  ###############
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -3,7 +3,7 @@ MATH_ALL        = [MATH_DOTONLY; [:+, :-, :*, :/, :^]]
 COMPARE_DOTONLY = [:.>, :.<, :.==, :.>=, :.<=] 
 
 for op in [MATH_ALL; COMPARE_DOTONLY]
-  @eval import Base.$op
+  eval(Expr(:import, :Base, op))
 end # for
 
 ###### Mathematical operators  ###############

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -70,12 +70,12 @@ facts("base element-wise operators on TimeArray values") do
   context("correct alignment and operation between two TimeVectors") do
      @fact (cl .+ op).values[1]           => roughly(216.82)
      @fact (cl .- op).values[1]           => roughly(7.06)
-     @fact (cl .* op).values[1]           => roughly(11740.27)
-     @fact (cl ./ op).values[1]           => roughly(1.067315)
+     @fact (cl .* op).values[1]           => roughly(11740.2672)
+     @fact (cl ./ op).values[1]           => roughly(1.067315027)
   end
 
   context("only values on intersecting Dates computed") do
-     @fact (cl[1:2] ./ op[2:3]).values[1] => roughly(0.946882) 
+     @fact (cl[1:2] ./ op[2:3]).values[1] => roughly(0.94688222) 
      @fact (cl[1:4] .+ op[4:7]).values[1] => roughly(201.12)
      @fact length(cl[1:2] ./ op[2:3])     => 1
      @fact length(cl[1:4] .+ op[4:7])     => 1
@@ -97,7 +97,7 @@ facts("base element-wise operators on TimeArray values") do
   context("element-wise mathematical operations between 2d time array and 1d time array") do
      @fact (ohlc .+ cl).values[1,1] => roughly(216.82)
      @fact (ohlc .+ cl).values[1,2] => roughly(224.44)
-     @fact (ohlc .* cl).values[1,1] => roughly(11740.27)
+     @fact (ohlc .* cl).values[1,1] => roughly(11740.2672)
      @fact (ohlc .* cl).values[1,2] => roughly(12593.25)
   end
 

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -3,147 +3,147 @@ using MarketData
 facts("time series methods") do
 
   context("lag takes previous day and timestamps it to next day") do
-      @fact lag(cl).values[1]    => roughly(111.94) 
-      @fact lag(cl).timestamp[1] => Date(2000,1,4)
+      @fact lag(cl).values[1]    --> roughly(111.94) 
+      @fact lag(cl).timestamp[1] --> Date(2000,1,4)
   end
 
   context("lag accepts kwarg") do
-      @fact lag(cl, period=9).timestamp[1] => Date(2000,1,14)
+      @fact lag(cl, period=9).timestamp[1] --> Date(2000,1,14)
   end
 
   context("lag operates on 2d arrays") do
-      @fact lag(ohlc, period=9).timestamp[1] => Date(2000,1,14)
+      @fact lag(ohlc, period=9).timestamp[1] --> Date(2000,1,14)
   end
 
   context("lag returns 1d from 1d time arrays") do
-      @fact ndims(lag(cl).values) => 1
+      @fact ndims(lag(cl).values) --> 1
   end
 
   context("lag returns 2d from 2d time arrays") do
-      @fact ndims(lag(ohlc).values) => 2
+      @fact ndims(lag(ohlc).values) --> 2
   end
 
   context("lead takes next day and timestamps it to current day") do
-      @fact lead(cl).values[1]    => roughly(102.5) 
-      @fact lead(cl).timestamp[1] => Date(2000,1,3)
+      @fact lead(cl).values[1]    --> roughly(102.5) 
+      @fact lead(cl).timestamp[1] --> Date(2000,1,3)
   end
 
   context("lead accepts kwarg") do
-      @fact lead(cl, period=9).values[1]    => 100.44 
-      @fact lead(cl, period=9).timestamp[1] => Date(2000,1,3)
+      @fact lead(cl, period=9).values[1]    --> 100.44 
+      @fact lead(cl, period=9).timestamp[1] --> Date(2000,1,3)
   end
 
   context("lead operates on 2d arrays") do
-      @fact lead(ohlc, period=9).timestamp[1] => Date(2000,1,3)
+      @fact lead(ohlc, period=9).timestamp[1] --> Date(2000,1,3)
   end
 
   context("lead returns 1d from 1d time arrays") do
-      @fact ndims(lead(cl).values) => 1
+      @fact ndims(lead(cl).values) --> 1
   end
 
   context("lead returns 2d from 2d time arrays") do
-      @fact ndims(lead(ohlc).values) => 2
+      @fact ndims(lead(ohlc).values) --> 2
   end
 
   context("correct simple return value") do
-      @fact percentchange(cl).values[1] => roughly((102.5-111.94)/111.94)
+      @fact percentchange(cl).values[1] --> roughly((102.5-111.94)/111.94)
   end
 
   context("correct log return value") do
-      @fact percentchange(cl, method="log").values[1] => roughly(log(102.5) - log(111.94))
+      @fact percentchange(cl, method="log").values[1] --> roughly(log(102.5) - log(111.94))
   end
 
   context("moving supplies correct window length") do
-      @fact moving(cl, mean, 10).values[1]    => roughly(sum(cl.values[1:10])/10)
-      @fact moving(cl, mean, 10).timestamp[1] => Date(2000,1,14)
+      @fact moving(cl, mean, 10).values[1]    --> roughly(sum(cl.values[1:10])/10)
+      @fact moving(cl, mean, 10).timestamp[1] --> Date(2000,1,14)
   end
  
   context("upto method accumulates") do
-      @fact upto(cl, sum).values[10]    => roughly(sum(cl.values[1:10]))
-      @fact upto(cl, mean).values[10]   => roughly(sum(cl.values[1:10])/10)
-      @fact upto(cl, sum).timestamp[10] => Date(2000,1,14)
+      @fact upto(cl, sum).values[10]    --> roughly(sum(cl.values[1:10]))
+      @fact upto(cl, mean).values[10]   --> roughly(sum(cl.values[1:10])/10)
+      @fact upto(cl, sum).timestamp[10] --> Date(2000,1,14)
   end
 end
 
 facts("base element-wise operators on TimeArray values") do
 
   context("correct alignment and operation between two TimeVectors") do
-     @fact (cl .+ op).values[1]           => roughly(216.82)
-     @fact (cl .- op).values[1]           => roughly(7.06)
-     @fact (cl .* op).values[1]           => roughly(11740.2672)
-     @fact (cl ./ op).values[1]           => roughly(1.067315027)
+     @fact (cl .+ op).values[1]           --> roughly(216.82)
+     @fact (cl .- op).values[1]           --> roughly(7.06)
+     @fact (cl .* op).values[1]           --> roughly(11740.2672)
+     @fact (cl ./ op).values[1]           --> roughly(1.067315027)
   end
 
   context("only values on intersecting Dates computed") do
-     @fact (cl[1:2] ./ op[2:3]).values[1] => roughly(0.94688222) 
-     @fact (cl[1:4] .+ op[4:7]).values[1] => roughly(201.12)
-     @fact length(cl[1:2] ./ op[2:3])     => 1
-     @fact length(cl[1:4] .+ op[4:7])     => 1
+     @fact (cl[1:2] ./ op[2:3]).values[1] --> roughly(0.94688222) 
+     @fact (cl[1:4] .+ op[4:7]).values[1] --> roughly(201.12)
+     @fact length(cl[1:2] ./ op[2:3])     --> 1
+     @fact length(cl[1:4] .+ op[4:7])     --> 1
   end
 
   context("correct dot operation between TimeVectors values and Int/Float64 and viceversa") do
-     @fact (cl .- 100).values[1] => roughly(11.94)
-     @fact (cl .+ 100).values[1] => roughly(211.94)
-     @fact (cl .* 100).values[1] => roughly(11194)
-     @fact (cl ./ 100).values[1] => roughly(1.1194)
-     @fact (cl .^ 2).values[1]   => roughly(12530.5636)
-     @fact (100 .- cl).values[1] => roughly(-11.94)
-     @fact (100 .+ cl).values[1] => roughly(211.94)
-     @fact (100 .* cl).values[1] => roughly(11194)
-     @fact (100 ./ cl).values[1] => roughly(0.8933357155619082)
-     @fact (2 .^ cl).values[1]   => 4980784073277740581384811358191616
+     @fact (cl .- 100).values[1] --> roughly(11.94)
+     @fact (cl .+ 100).values[1] --> roughly(211.94)
+     @fact (cl .* 100).values[1] --> roughly(11194)
+     @fact (cl ./ 100).values[1] --> roughly(1.1194)
+     @fact (cl .^ 2).values[1]   --> roughly(12530.5636)
+     @fact (100 .- cl).values[1] --> roughly(-11.94)
+     @fact (100 .+ cl).values[1] --> roughly(211.94)
+     @fact (100 .* cl).values[1] --> roughly(11194)
+     @fact (100 ./ cl).values[1] --> roughly(0.8933357155619082)
+     @fact (2 .^ cl).values[1]   --> 4980784073277740581384811358191616
   end
 
   context("element-wise mathematical operations between 2d time array and 1d time array") do
-     @fact (ohlc .+ cl).values[1,1] => roughly(216.82)
-     @fact (ohlc .+ cl).values[1,2] => roughly(224.44)
-     @fact (ohlc .* cl).values[1,1] => roughly(11740.2672)
-     @fact (ohlc .* cl).values[1,2] => roughly(12593.25)
+     @fact (ohlc .+ cl).values[1,1] --> roughly(216.82)
+     @fact (ohlc .+ cl).values[1,2] --> roughly(224.44)
+     @fact (ohlc .* cl).values[1,1] --> roughly(11740.2672)
+     @fact (ohlc .* cl).values[1,2] --> roughly(12593.25)
   end
 
   context("correct non-dot operation between TimeVectors values and Int/Float64 and viceversa") do
-     @fact (cl - 100).values[1] => roughly(11.94)
-     @fact (cl + 100).values[1] => roughly(211.94)
-     @fact (cl * 100).values[1] => roughly(11194)
-     @fact (cl / 100).values[1] => roughly(1.1194)
-     @pending (cl ^ 2).values[1]   => roughly(12530.5636)
-     @fact (100 - cl).values[1] => roughly(-11.94)
-     @fact (100 + cl).values[1] => roughly(211.94)
-     @fact (100 * cl).values[1] => roughly(11194)
-     #@fact (100 / cl).values[1] => roughly(0.8933357155619082)
+     @fact (cl - 100).values[1] --> roughly(11.94)
+     @fact (cl + 100).values[1] --> roughly(211.94)
+     @fact (cl * 100).values[1] --> roughly(11194)
+     @fact (cl / 100).values[1] --> roughly(1.1194)
+     @pending (cl ^ 2).values[1]   --> roughly(12530.5636)
+     @fact (100 - cl).values[1] --> roughly(-11.94)
+     @fact (100 + cl).values[1] --> roughly(211.94)
+     @fact (100 * cl).values[1] --> roughly(11194)
+     #@fact (100 / cl).values[1] --> roughly(0.8933357155619082)
      @fact_throws (100 / cl).values[1] # related to base not supporting this 
-     @pending (2 ^ cl).values[1]   => 4980784073277740581384811358191616
+     @pending (2 ^ cl).values[1]   --> 4980784073277740581384811358191616
   end
 
   context("correct operation between two TimeVectors values returns bool for comparisons") do
-     @fact (cl .> op).values[1]  => true
-     @fact (cl .< op).values[1]  => false
-     @fact (cl .<= op).values[1] => false
-     @fact (cl .>= op).values[1] => true
-     @fact (cl .== op).values[1] => false
+     @fact (cl .> op).values[1]  --> true
+     @fact (cl .< op).values[1]  --> false
+     @fact (cl .<= op).values[1] --> false
+     @fact (cl .>= op).values[1] --> true
+     @fact (cl .== op).values[1] --> false
   end
 
   context("correct operation between TimeVectors values and Int/Float64 (and viceversa) returns bool for comparison") do
-     @fact (cl .> 111.94).values[1]  => false
-     @fact (cl .< 111.94).values[1]  => false
-     @fact (cl .>= 111.94).values[1] => true
-     @fact (cl .<= 111.94).values[1] => true
-     @fact (cl .== 111.94).values[1] => true
-     @fact (111.94 .> cl).values[1]  => false
-     @fact (111.94 .< cl).values[1]  => false
-     @fact (111.94 .>= cl).values[1] => true
-     @fact (111.94 .<= cl).values[1] => true
-     @fact (111.94 .== cl).values[1] => true
+     @fact (cl .> 111.94).values[1]  --> false
+     @fact (cl .< 111.94).values[1]  --> false
+     @fact (cl .>= 111.94).values[1] --> true
+     @fact (cl .<= 111.94).values[1] --> true
+     @fact (cl .== 111.94).values[1] --> true
+     @fact (111.94 .> cl).values[1]  --> false
+     @fact (111.94 .< cl).values[1]  --> false
+     @fact (111.94 .>= cl).values[1] --> true
+     @fact (111.94 .<= cl).values[1] --> true
+     @fact (111.94 .== cl).values[1] --> true
   end
 end
 
 facts("basecall works with Base methods") do
   
   context("cumsum works") do
-    @fact basecall(cl, cumsum).values[2] => cl.values[1] + cl.values[2]
+    @fact basecall(cl, cumsum).values[2] --> cl.values[1] + cl.values[2]
   end
   
   context("log works") do
-    @fact basecall(cl, log).values[2] => log(cl.values[2])
+    @fact basecall(cl, log).values[2] --> log(cl.values[2])
   end
 end

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -3,43 +3,43 @@ using MarketData
 facts("collapse operations") do
 
     context("collapse squishes correctly") do
-        @fact collapse(cl, last).values[1]                  => 99.50
-        @fact collapse(cl, last).timestamp[1]               => Date(2000,1,7)
-        @fact collapse(cl, last, period=month).values[1]    => 103.75
-        @fact collapse(cl, last, period=month).timestamp[1] => Date(2000,1,31)
+        @fact collapse(cl, last).values[1]                  --> 99.50
+        @fact collapse(cl, last).timestamp[1]               --> Date(2000,1,7)
+        @fact collapse(cl, last, period=month).values[1]    --> 103.75
+        @fact collapse(cl, last, period=month).timestamp[1] --> Date(2000,1,31)
     end
 end
 
 facts("merge works correctly") do
 
     context("takes colnames kwarg correctly") do
-        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] => "a"
-        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] => "b"
-        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] => "c"
-        @fact merge(cl,op, col_names=["a","b"]).colnames[1]                      => "a"
-        @fact merge(cl,op, col_names=["a","b"]).colnames[2]                      => "b"
-        @fact merge(cl,op, col_names=["a"]).colnames[1]                          => "Close"
-        @fact merge(cl,op, col_names=["a"]).colnames[2]                          => "Open"
+        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[1] --> "a"
+        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[2] --> "b"
+        @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] --> "c"
+        @fact merge(cl,op, col_names=["a","b"]).colnames[1]                      --> "a"
+        @fact merge(cl,op, col_names=["a","b"]).colnames[2]                      --> "b"
+        @fact merge(cl,op, col_names=["a"]).colnames[1]                          --> "Close"
+        @fact merge(cl,op, col_names=["a"]).colnames[2]                          --> "Open"
         @fact_throws merge(cl,op, col_names=["a","b","c"])
         @fact_throws merge(cl,op, col_names=["a","b","c"])
     end
   
     context("returns correct alignment with Dates and values") do
-        @fact merge(cl,op).values[2,1] => cl.values[2,1]
-        @fact merge(cl,op).values[2,2] => op.values[2,1]
+        @fact merge(cl,op).values[2,1] --> cl.values[2,1]
+        @fact merge(cl,op).values[2,2] --> op.values[2,1]
     end
     
     context("aligns with disparate sized objects") do
-        @fact merge(cl, op[2:5]).values[1,1]  => cl.values[2,1]
-        @fact merge(cl, op[2:5]).values[1,2]  => op.values[2,1]
-        @fact merge(cl, op[2:5]).timestamp[1] => Date(2000,1,4)
-        @fact length(merge(cl, op[2:5]))      => 4
+        @fact merge(cl, op[2:5]).values[1,1]  --> cl.values[2,1]
+        @fact merge(cl, op[2:5]).values[1,2]  --> op.values[2,1]
+        @fact merge(cl, op[2:5]).timestamp[1] --> Date(2000,1,4)
+        @fact length(merge(cl, op[2:5]))      --> 4
     end
 
     context("column names match the correct values") do
-        @fact merge(cl, op[2:5]).colnames[1]  => "Close"
-        @fact merge(cl, op[2:5]).colnames[2]  => "Open"
-        @fact merge(op[2:5], cl).colnames[1]  => "Open"
-        @fact merge(op[2:5], cl).colnames[2]  => "Close"
+        @fact merge(cl, op[2:5]).colnames[1]  --> "Close"
+        @fact merge(cl, op[2:5]).colnames[2]  --> "Open"
+        @fact merge(op[2:5], cl).colnames[1]  --> "Open"
+        @fact merge(op[2:5], cl).colnames[2]  --> "Close"
     end
 end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -3,76 +3,76 @@ using MarketData
 facts("construction with and without meta field") do
 
     context("default meta field to Nothing") do
-        @pending cl.meta => Void
-        @pending cl.meta => Nothing
+        @pending cl.meta --> Void
+        @pending cl.meta --> Nothing
     end
 
     context("allow objects in meta field") do
-        @fact mdata.meta => "Apple"
+        @fact mdata.meta --> "Apple"
     end
 end
 
 facts("get index operations preserve meta") do
 
     context("index by integer row") do
-        @fact mdata[1].meta => "Apple"
+        @fact mdata[1].meta --> "Apple"
     end
 
     context("index by integer range") do
-        @fact mdata[1:2].meta => "Apple"
+        @fact mdata[1:2].meta --> "Apple"
     end
 
     context("index by column name") do
-        @fact mdata["Close"].meta => "Apple"
+        @fact mdata["Close"].meta --> "Apple"
     end
 
     context("index by date range") do
-        @fact mdata[[Date(2000,1,3), Date(2000,1,14)]].meta => "Apple"
+        @fact mdata[[Date(2000,1,3), Date(2000,1,14)]].meta --> "Apple"
     end
 end
    
 facts("split operations preserve meta") do
 
     context("by") do
-        @fact by(mdata, 1, period=dayofweek).meta => "Apple"
+        @fact by(mdata, 1, period=dayofweek).meta --> "Apple"
     end
 
     context("from") do
-        @fact from(mdata, 2000,1,1).meta => "Apple"
+        @fact from(mdata, 2000,1,1).meta --> "Apple"
     end
   
     context("to") do
-        @fact to(mdata, 2000,1,1).meta => "Apple"
+        @fact to(mdata, 2000,1,1).meta --> "Apple"
     end
 end
 
 facts("apply operations preserve meta") do
 
     context("lag") do
-        @fact lag(mdata).meta => "Apple"
+        @fact lag(mdata).meta --> "Apple"
     end
 
     context("lead") do
-        @fact lead(mdata).meta => "Apple"
+        @fact lead(mdata).meta --> "Apple"
     end
 
     context("percentchange") do
-        @fact percentchange(mdata).meta => "Apple"
+        @fact percentchange(mdata).meta --> "Apple"
     end
 
     context("moving") do
-        @fact moving(mdata,mean,10).meta => "Apple"
+        @fact moving(mdata,mean,10).meta --> "Apple"
     end
      
     context("upto") do
-        @fact upto(mdata,sum).meta => "Apple"
+        @fact upto(mdata,sum).meta --> "Apple"
     end
 end
 
 facts("combine operations preserve meta") do
 
     context("merge when both have identical meta") do
-        @fact merge(mdata, mdata).meta => "Apple"
+        @fact merge(mdata, mdata).meta --> "Apple"
     end
 
     context("merge when both have different meta") do
@@ -80,31 +80,31 @@ facts("combine operations preserve meta") do
     end
 
     context("collapse") do
-        @fact collapse(mdata, last).meta => "Apple"
+        @fact collapse(mdata, last).meta --> "Apple"
     end
 end
 
 facts("basecall operations preserve meta") do
 
     context("basecall") do
-        @fact basecall(mdata, cumsum).meta => "Apple"
+        @fact basecall(mdata, cumsum).meta --> "Apple"
     end
 end
 
 facts("mathematical and comparison operations preserve meta") do
 
     context(".+") do
-        @fact (mdata .+ mdata).meta => "Apple"
+        @fact (mdata .+ mdata).meta --> "Apple"
     end
 
     context(".<") do
-        @fact (mdata .< mdata).meta => "Apple"
+        @fact (mdata .< mdata).meta --> "Apple"
     end
 end
 
 facts("readwrite accepts meta argument") do
 
     context("Apple is present") do
-        @fact mdata.meta => "Apple"
+        @fact mdata.meta --> "Apple"
     end
 end

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -3,27 +3,27 @@ using MarketData
 facts("readwrite parses csv file correctly") do
 
   context("1d values array works") do
-      @fact typeof(cl.values) => Array{Float64,1}
+      @fact typeof(cl.values) --> Array{Float64,1}
   end
 
   context("2d values array works") do
-      @fact typeof(ohlc.values) => Array{Float64,2}
+      @fact typeof(ohlc.values) --> Array{Float64,2}
   end
 
   context("Specifying DateTime string format for reading") do
       ta = readtimearray(Pkg.dir("TimeSeries/test/data/datetime3.csv"), format="yyyy/mm/dd|HH:MM:SS")
-      @fact length(ta) => 5
-      @fact size(ta.values) => (5,1)
-      @fact ta.timestamp[4] => DateTime(2010,1,4,9,4)
+      @fact length(ta) --> 5
+      @fact size(ta.values) --> (5,1)
+      @fact ta.timestamp[4] --> DateTime(2010,1,4,9,4)
       @fact_throws readtimearray(Pkg.dir("TimeSeries/test/data/datetime3.csv"))
   end
 
   context("timestamp parses to correct type") do
-      @fact typeof(cl.timestamp)        => Vector{Date}
-      @fact typeof(datetime1.timestamp) => Vector{DateTime}
+      @fact typeof(cl.timestamp)        --> Vector{Date}
+      @fact typeof(datetime1.timestamp) --> Vector{DateTime}
   end
 
   context("readtimearray accepts meta field") do
-      @pending mdata => "construct mdata from csv vs reconstructing a Time Array" 
+      @pending mdata --> "construct mdata from csv vs reconstructing a Time Array" 
   end
 end

--- a/test/split.jl
+++ b/test/split.jl
@@ -3,38 +3,38 @@ using MarketData
 facts("find methods") do
 
   context("findall returns correct row numbers array") do
-     @fact cl[findall(cl .> op)].timestamp[1] => Date(2000,1,3)
-     @fact length(findall(cl .> op))          => 244
+     @fact cl[findall(cl .> op)].timestamp[1] --> Date(2000,1,3)
+     @fact length(findall(cl .> op))          --> 244
   end
 
   context("findwhen returns correct Dates array") do
-#     @fact findwhen(cl .> op)[1]      => Date(2000,1,3)
-#     @fact length(findwhen(cl .> op)) => 244 
+#     @fact findwhen(cl .> op)[1]      --> Date(2000,1,3)
+#     @fact length(findwhen(cl .> op)) --> 244 
   end
 end
 
 facts("split date operations") do
 
   context("from and to correctly subset") do
-     @fact length(from(cl, 2001,12,28)) => 2
-     @fact length(to(cl, 2000,1,4))     => 2
+     @fact length(from(cl, 2001,12,28)) --> 2
+     @fact length(to(cl, 2000,1,4))     --> 2
   end
 
   context("bydate methods correctly subset") do
-     @fact by(cl,2001, period=year).timestamp[1]   => Date(2001,1,2)
-     @fact by(cl,2, period=month).timestamp[1]     => Date(2000,2,1)
-     @fact by(cl,4, period=day).timestamp[1]       => Date(2000,1,4) 
-     @fact by(cl,5, period=dayofweek).timestamp[1] => Date(2000,1,7)
-     @fact by(cl,4, period=dayofyear).timestamp[1] => Date(2000,1,4)
+     @fact by(cl,2001, period=year).timestamp[1]   --> Date(2001,1,2)
+     @fact by(cl,2, period=month).timestamp[1]     --> Date(2000,2,1)
+     @fact by(cl,4, period=day).timestamp[1]       --> Date(2000,1,4) 
+     @fact by(cl,5, period=dayofweek).timestamp[1] --> Date(2000,1,7)
+     @fact by(cl,4, period=dayofyear).timestamp[1] --> Date(2000,1,4)
   end
 end
 
 facts("element wrappers") do
 
   context("type element wrappers isolate elements") do
-     @fact isa(timestamp(cl), Array{Date,1}) => true
-     @fact isa(values(cl), Array{Float64,1})              => true
-     @fact isa(values(ohlc), Array{Float64,2})            => true
-     @fact isa(colnames(cl), Array{UTF8String, 1})       => true
+     @fact isa(timestamp(cl), Array{Date,1}) --> true
+     @fact isa(values(cl), Array{Float64,1})              --> true
+     @fact isa(values(ohlc), Array{Float64,2})            --> true
+     @fact isa(colnames(cl), Array{UTF8String, 1})       --> true
   end
 end

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -1,10 +1,10 @@
 using MarketData
 
 facts("field extraction methods work") do
-    @fact typeof(timestamp(cl)) => Array{Date,1}
-    @fact typeof(values(cl))    => Array{Float64,1}
-    @fact typeof(colnames(cl))  => Array{UTF8String,1}
-    @pending meta(mdata)        => "Apple" 
+    @fact typeof(timestamp(cl)) --> Array{Date,1}
+    @fact typeof(values(cl))    --> Array{Float64,1}
+    @fact typeof(colnames(cl))  --> Array{UTF8String,1}
+    @pending meta(mdata)        --> "Apple" 
 end
 
 facts("type constructors enforce invariants") do
@@ -26,59 +26,59 @@ facts("type constructors enforce invariants") do
   end
 
   context("flipping occurs when needed") do
-    @fact TimeArray(flipdim(cl.timestamp, 1), flipdim(cl.values, 1),  ["Close"]).timestamp[1] => Date(2000,1,3)
-    @fact TimeArray(flipdim(cl.timestamp, 1), flipdim(cl.values, 1),  ["Close"]).values[1]    => 111.94
+    @fact TimeArray(flipdim(cl.timestamp, 1), flipdim(cl.values, 1),  ["Close"]).timestamp[1] --> Date(2000,1,3)
+    @fact TimeArray(flipdim(cl.timestamp, 1), flipdim(cl.values, 1),  ["Close"]).values[1]    --> 111.94
   end
 end
   
 facts("conversion methods") do
-    @fact isa(convert(TimeArray{Float64,1}, (cl.>op)), TimeArray{Float64,1})                => true
-    @fact isa(convert(TimeArray{Float64,2}, (merge(cl.<op, cl.>op))), TimeArray{Float64,2}) => true
-    @fact isa(convert(cl.>op), TimeArray{Float64,1})                                        => true
-    @fact isa(convert(merge(cl.<op, cl.>op)), TimeArray{Float64,2})                         => true
+    @fact isa(convert(TimeArray{Float64,1}, (cl.>op)), TimeArray{Float64,1})                --> true
+    @fact isa(convert(TimeArray{Float64,2}, (merge(cl.<op, cl.>op))), TimeArray{Float64,2}) --> true
+    @fact isa(convert(cl.>op), TimeArray{Float64,1})                                        --> true
+    @fact isa(convert(merge(cl.<op, cl.>op)), TimeArray{Float64,2})                         --> true
 end
 
 facts("getindex methods") do
   
   context("getindex on single Int and Date") do
-    @fact ohlc[1].timestamp              => [Date(2000,1,3)]
-    @fact ohlc[Date(2000,1,3)].timestamp => [Date(2000,1,3)]
+    @fact ohlc[1].timestamp              --> [Date(2000,1,3)]
+    @fact ohlc[Date(2000,1,3)].timestamp --> [Date(2000,1,3)]
   end
   
   context("getindex on array of Int and Date") do
-    @fact ohlc[[1,10]].timestamp                           => [Date(2000,1,3), Date(2000,1,14)]
-    @fact ohlc[[Date(2000,1,3),Date(2000,1,14)]].timestamp => [Date(2000,1,3), Date(2000,1,14)]
+    @fact ohlc[[1,10]].timestamp                           --> [Date(2000,1,3), Date(2000,1,14)]
+    @fact ohlc[[Date(2000,1,3),Date(2000,1,14)]].timestamp --> [Date(2000,1,3), Date(2000,1,14)]
   end
 
   context("getindex on range of Int and Date") do
-    @fact ohlc[1:2].timestamp                                  => [Date(2000,1,3), Date(2000,1,4)]
-    @fact ohlc[Date(2000,1,3):Day(1):Date(2000,1,4)].timestamp => [Date(2000,1,3), Date(2000,1,4)]
+    @fact ohlc[1:2].timestamp                                  --> [Date(2000,1,3), Date(2000,1,4)]
+    @fact ohlc[Date(2000,1,3):Day(1):Date(2000,1,4)].timestamp --> [Date(2000,1,3), Date(2000,1,4)]
   end
 
   # TODO get meaningful tests
   context("getindex on range of DateTime when only Date is in timestamp") do
-    @fact ohlc[DateTime(2000,1,3,0,0,0)].timestamp                                 => [DateTime(2000,1,3,0,0,0)]
-    @fact ohlc[[DateTime(2000,1,3,0,0,0),DateTime(2000,1,14,0,0,0)]].timestamp     => [DateTime(2000,1,3,0,0,0), DateTime(2000,1,14,0,0,0)]
-    @fact ohlc[DateTime(2000,1,3,0,0,0):Day(1):DateTime(2000,1,4,0,0,0)].timestamp => [DateTime(2000,1,3,0,0,0), DateTime(2000,1,4,0,0,0)]
+    @fact ohlc[DateTime(2000,1,3,0,0,0)].timestamp                                 --> [DateTime(2000,1,3,0,0,0)]
+    @fact ohlc[[DateTime(2000,1,3,0,0,0),DateTime(2000,1,14,0,0,0)]].timestamp     --> [DateTime(2000,1,3,0,0,0), DateTime(2000,1,14,0,0,0)]
+    @fact ohlc[DateTime(2000,1,3,0,0,0):Day(1):DateTime(2000,1,4,0,0,0)].timestamp --> [DateTime(2000,1,3,0,0,0), DateTime(2000,1,4,0,0,0)]
   end
 
   context("getindex on range of Date") do
-    @fact length(cl[Date(2000,1,1):Date(2001,12,31)]) => 500
+    @fact length(cl[Date(2000,1,1):Date(2001,12,31)]) --> 500
   end
 
   context("getindex on single column name") do
-    @fact size(ohlc["Open"].values, 2)                                        => 1
-    @fact size(ohlc["Open"][Date(2000,1,3):Day(1):Date(2000,1,14)].values, 1) => 10
+    @fact size(ohlc["Open"].values, 2)                                        --> 1
+    @fact size(ohlc["Open"][Date(2000,1,3):Day(1):Date(2000,1,14)].values, 1) --> 10
   end
 
   context("getindex on multiple column name") do
-    @fact ohlc["Open", "Close"].values[1]   => 104.88
-    @fact ohlc["Open", "Close"].values[2]   => 108.25
-    @fact ohlc["Open", "Close"].values[501] => 111.94
+    @fact ohlc["Open", "Close"].values[1]   --> 104.88
+    @fact ohlc["Open", "Close"].values[2]   --> 108.25
+    @fact ohlc["Open", "Close"].values[501] --> 111.94
   end
 
   context("getindex on 1d returns 1d object") do
-    @fact isa(cl[1], TimeArray{Float64,1})   => true
-    @fact isa(cl[1:2], TimeArray{Float64,1}) => true
+    @fact isa(cl[1], TimeArray{Float64,1})   --> true
+    @fact isa(cl[1:2], TimeArray{Float64,1}) --> true
   end
 end

--- a/test/timeseriesrc.jl
+++ b/test/timeseriesrc.jl
@@ -4,10 +4,10 @@ include(Pkg.dir("TimeSeries/src/.timeseriesrc.jl"))
 facts("const values are set the package defaults") do
 
   context("SHOWINT") do
-      @fact SHOWINT => true
+      @fact SHOWINT --> true
   end
 
   context("DECIMALS") do
-      @fact DECIMALS => 4
+      @fact DECIMALS --> 4
   end
 end


### PR DESCRIPTION
Explicitly import math/inequality operators from Base to remove new 0.4 warnings like:

`WARNING: module TimeSeries should explicitly import .+ from Base`

A few tests had also started failing due a lack of agreeing significant digits with the FactCheck `roughly` function, e.g.

```
Failure :: (line:-1) :: correct alignment and operation between two TimeVectors :: fact was false
      Expression: cl .* op.values[1] --> roughly(11740.27)
        Expected: 11740.267199999998 ≅ 11740.27
```

so I increased the precision of the expected results.