### PR TITLE
Switch to AbstractArrays and refactor / generalize operator code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+### 0.6.1
+
+* generalized value container from Array to AbstractArray
+* implemented new element-wise operators: !, ~, &, |, $, %, !==
+* implemented element-wise unary math operators (+, -)
+
 ### 0.6.0
 
 * first version with support for Julia 0.4 only
@@ -16,7 +22,7 @@
 * changed references of float(x) to map(Float64, x)
 * changed references of [a] to [a;] in a comprehension found in the by() method
 * added Compat package
-* substantial speedup for eleemnt-wise mathematical operators
+* substantial speedup for element-wise mathematical operators
 
 ### 0.5.9
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.3 0.4-
-Dates
+julia 0.4- 0.5-

--- a/docs/source/operators.rst
+++ b/docs/source/operators.rst
@@ -1,22 +1,23 @@
-Mathematical and comparison operators
-=====================================
+Mathematical, comparison, and logical operators
+===============================================
 
-TimeSeries supports common mathematical (such as ``+``) and comparison ( such as ``==``)
-operators. The operations are only calculated on values that share a timestamp.
+TimeSeries supports common mathematical (such as ``+``), comparison ( such as ``.==``)
+, and logic (such as ``&``) operators. The operations are only calculated on values that share a timestamp.
 
 mathematical
 ------------
 
 Mathematical operators create a TimeArray object where values are computed on shared timestamps when two TimeArray 
-objects are provided. Operations between a single TimeArray and ``Int`` or ``Float`` is also supported. The number 
-can precede the TimeArray object or vice versa (e.g. ``cl + 2`` or ``2 + cl``).
+objects are provided. Operations between a single TimeArray and ``Int`` or ``Float`` are also supported. The number
+can precede the TimeArray object or vice versa (e.g. ``cl + 2`` or ``2 + cl``). Broadcasting single-column arrays over multiple columns to perform operations is also supported.
 
-Except in the case of the ``/`` operator, both dot (``.+``) and non-dot (``+``) operations are supported. The semantics
+Except in the case of the ``/`` and ``^`` operators, both dot (``.+``) and non-dot (``+``) operations are supported when working with scalar values. The semantics
 of non-dot operations are fairly clear when working with time series data, where it is assumed that only equivalent 
 timestamped values are being operated on. 
 
-The exclusion of ``/`` from this logic is a special case. In matrix operations it has been confused with being 
-equivalent to the inverse, and because of the confusion base has excluded it. It is likewise excluded here. 
+The exclusion of ``/`` and ``^`` from this logic are special cases. In matrix operations ``/`` has been confused with being
+equivalent to the inverse, and because of the confusion base has excluded it. It is likewise excluded here. Base uses ``^`` to indicate matrix self-multiplication, and so it is not implemented
+ in this context.
 
 +------------------+------------------------------------------+
 | Operator         | Description                              |
@@ -27,15 +28,19 @@ equivalent to the inverse, and because of the confusion base has excluded it. It
 +------------------+------------------------------------------+
 | ``*`` or  ``.*`` | mathematical element-wise multiplication |
 +------------------+------------------------------------------+
-|      ``/``       | mathematical element-wise division       |
+|      ``./``      | mathematical element-wise division       |
++------------------+------------------------------------------+
+|      ``.^``      | mathematical element-wise exponentiation |
++------------------+------------------------------------------+
+| ``%`` or ``.%``  | mathematical element-wise remainder      |
 +------------------+------------------------------------------+
 
 comparison
 ----------
 
 Comparison operators create a TimeArray of type ``Bool``. Values are compared on shared timestamps when two TimeArray 
-objects are provided. Comparison between a single TimeArray and ``Int`` or ``Float`` is also supported. The semantics of
-an non-dot operators (``>``) is unclear, so it is not supported.
+objects are provided. Broadcasting single-column arrays over multiple columns to perform comparisonsis supported, as are comparisons between a single TimeArray and ``Int``, ``Float``, or ``Bool`` values.  The semantics of
+an non-dot operators (``>``) is unclear, and such operators are not supported.
 
 +---------+-----------------------------------------------+
 | Operator| Description                                   |
@@ -50,3 +55,24 @@ an non-dot operators (``>``) is unclear, so it is not supported.
 +---------+-----------------------------------------------+
 | ``.<=`` | element-wise less-than or equal comparison    |
 +---------+-----------------------------------------------+
+| ``.!=`` | element-wise not-equivalent comparison        |
++---------+-----------------------------------------------+
+
+logic
+-----
+
+Logical operators are defined for TimeArrays of type ``Bool`` and return a TimeArray of type ``Bool``. Values are computed on shared timestamps when two TimeArray 
+objects are provided. Operations between a single TimeArray and ``Bool`` are also supported. In keeping with base, broadcasting of logical operators is not supported.
+
++---------+---------------------------------+
+| Operator| Description                     |
++=========+=================================+
+|     ``&``   | element-wise logical AND        |
++-------------+-----------------------------+
+|     ``|``   | element-wise logical OR         |
++-------------+-----------------------------+
+| ``!``,``~`` | element-wise logical NOT        |
++-------------+-----------------------------+
+|     ``$``   | element-wise logical XOR        |
++-------------+-----------------------------+
+

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,132 +1,123 @@
-MATH_DOTONLY    = [:.+, :.-, :.*, :./, :.^]
-MATH_ALL        = [MATH_DOTONLY; [:+, :-, :*, :/, :^]]
-COMPARE_DOTONLY = [:.>, :.<, :.==, :.>=, :.<=] 
+UNARY = [:+, :-, :~, :!]
+MATH_DOTONLY    = [:.+, :.-, :.*, :./, :.%, :.^]
+MATH_ALL        = [MATH_DOTONLY; [:+, :-, :*, :/, :%]]
+COMPARE_DOTONLY = [:.>, :.<, :.==, :.>=, :.<=, :.!=]
+BOOLEAN_OPS     = [:&; :|; :$; COMPARE_DOTONLY]
 
-for op in [MATH_ALL; COMPARE_DOTONLY]
+for op in [UNARY; MATH_ALL; BOOLEAN_OPS]
     eval(Expr(:import, :Base, op))
 end # for
 
-###### Mathematical operators  ###############
+###### Unary operators and functions ################
 
-# TimeArray <--> TimeArray 
-for op in MATH_DOTONLY
+# TimeArray
+for op in UNARY
     @eval begin
-        function ($op){T,N}(ta1::TimeArray{T,N}, ta2::TimeArray{T,N})
-          # first test metadata matches
-          ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
-          cname  = [ta1.colnames[1][1:2] *  string($op) *  ta2.colnames[1][1:2]]
-          idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
-          # obtain shared timestamp
-          tstamp = ta1[idx1].timestamp
-          # retrieve values that match the Int array matching dates
-          vals1  = ta1[idx1].values
-          vals2  = ta2[idx2].values
-          vals = Array(T, length(idx1))
-          for i in 1:length(vals)
-              vals[i] = ($op)(vals1[i], vals2[i])
-          end
-          TimeArray(tstamp, vals, cname, meta)
+        function ($op){T,N}(ta::TimeArray{T,N})
+            cnames  = [string($op) * name for name in ta.colnames]
+            vals = ($op)(ta.values)
+            TimeArray(ta.timestamp, vals, cnames, ta.meta)
         end # function
     end # eval
 end # loop
 
-# TimeArray (2d) <--> TimeArray (1d)
-for op in MATH_DOTONLY
+###### Numerical operations and comparisons #########
+
+# TimeArray <--> Scalar
+for op in [MATH_ALL; COMPARE_DOTONLY]
     @eval begin
-        function ($op){T}(ta1::TimeArray{T,2}, ta2::TimeArray{T,1})
-           # first test metadata matches
-           ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
-           # interate to find when there is a match on timestamp
-           counter = Int[]
-           for i in 1:length(ta1)
-               if in(ta1[i].timestamp[1], ta2.timestamp)
-                   push!(counter, i)
-               end
-           end
-           # create new shortened versions of ta1 and ta2
-           newta1 = ta1[counter]
-           newta2 = ta2[newta1.timestamp]
-
-           # operate on the values columns
-           vals = ($op)(ta1.values, ta2.values) 
-
-           cnames = repmat([""], length(ta1.colnames))
-           for i in 1:length(ta1.colnames)
-               cnames[i] = string(ta1.colnames[i])[1:2] * " " *  string($op) * " " *  string(ta2.colnames[1])[1:2]
-           end
-           TimeArray(newta1.timestamp, vals, cnames, meta)
+        function ($op){T<:Number,N}(ta::TimeArray{T,N}, var::Number)
+            cnames  = [name * string($op) * string(var) for name in ta.colnames]
+            vals = ($op)(ta.values, var)
+            TimeArray(ta.timestamp, vals, cnames, ta.meta)
         end # function
     end # eval
 end # loop
 
-# TimeArray <--> Int,Float64
-for op in MATH_ALL
+# Scalar <--> TimeArray
+for op in [MATH_ALL; COMPARE_DOTONLY]
     @eval begin
-        function ($op){T,N}(ta::TimeArray{T,N}, var::Union(Int,Float64))
-            vals = ($op)([t for t in ta.values], var)
-            TimeArray(ta.timestamp, vals, ta.colnames, ta.meta)
+        function ($op){T<:Number,N}(var::Number, ta::TimeArray{T,N})
+            cnames  = [string(var) * string($op) * name for name in ta.colnames]
+            vals = ($op)(var, ta.values)
+            TimeArray(ta.timestamp, vals, cnames, ta.meta)
         end # function
     end # eval
 end # loop
 
-# element-wise mathematical operations between an Int,Float64 and column
-for op in MATH_ALL
+# ND TimeArray <--> MD TimeArray
+for op in [MATH_DOTONLY; COMPARE_DOTONLY]
     @eval begin
-        function ($op){T,N}(var::Union(Int,Float64), ta::TimeArray{T,N})
-            vals = ($op)(var, [t for t in ta.values])
-            TimeArray(ta.timestamp, vals, ta.colnames, ta.meta)
+        function ($op){T<:Number,N,M}(ta1::TimeArray{T,N}, ta2::TimeArray{T,M})
+            # first test metadata matches
+            ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
+            # determine array widths and name cols accordingly
+            w1, w2  = length(ta1.colnames), length(ta2.colnames)
+            if w1 == w2
+              cnames = [ta1.colnames[i]*string($op)*ta2.colnames[i] for i=1:w1]
+            elseif w1==1
+              cnames = [ta1.colnames[1]*string($op)*ta2.colnames[i] for i=1:w2]
+            elseif w2==1
+              cnames = [ta1.colnames[i]*string($op)*ta2.colnames[1] for i=1:w1]
+            else
+              error("arrays must have the same number of columns, or one must be a single column")
+            end
+            # obtain shared timestamp
+            idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
+            tstamp = ta1[idx1].timestamp
+            # retrieve values that match the Int array matching dates
+            vals1, vals2 = ta1[idx1].values, ta2[idx2].values
+            # compute output values
+            vals = ($op)(vals1, vals2)
+            TimeArray(tstamp, vals, cnames, meta)
         end # function
     end # eval
 end # loop
 
-###### Comparison operators  ###############
+###### Boolean operations and comparisons ###############
 
-# TimeArray <--> TimeArray 
-for op in COMPARE_DOTONLY 
+# TimeArray <--> Bool
+for op in BOOLEAN_OPS
     @eval begin
-        function ($op){T,N}(ta1::TimeArray{T,N}, ta2::TimeArray{T,N})
-          # first test metadata matches
-          ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
-          cname  = [ta1.colnames[1][1:2] *  string($op) *  ta2.colnames[1][1:2]]
-          idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
-          # obtain shared timestamp
-          tstamp = ta1[idx1].timestamp
-          # retrieve values that match the Int array matching dates
-          vals1  = ta1[idx1].values
-          vals2  = ta2[idx2].values
-          vals = Array(Bool, length(idx1))
-          for i in 1:length(vals)
-              vals[i] = ($op)(vals1[i], vals2[i])
-          end
-          TimeArray(tstamp, vals, cname, meta)
+        function ($op){N}(ta::TimeArray{Bool,N}, var::Bool)
+            cnames = [name * string($op) * string(var) for name in ta.colnames]
+            vals   = ($op)(ta.values, var)
+            TimeArray(ta.timestamp, vals, cnames, ta.meta)
         end # function
     end # eval
 end # loop
 
-# TimeArray <--> Int,Float64
-for op in COMPARE_DOTONLY 
+# Bool <--> TimeArray
+for op in BOOLEAN_OPS
     @eval begin
-        function ($op){T,N}(ta::TimeArray{T,N}, var::Union(Int,Float64))
-          cname  = [ta.colnames[1][1:2] *  string($op) *  string(var)]
-          vals   = Array(Bool, length(ta))
-          for i in 1:length(vals)
-              vals[i] = ($op)(ta.values[i], var) 
-          end
-          TimeArray(ta.timestamp, vals, cname, ta.meta)
+        function ($op){N}(var::Bool, ta::TimeArray{Bool,N})
+            cnames = [string(var) * string($op) * name for name in ta.colnames]
+            vals   = ($op)(var, ta.values)
+            TimeArray(ta.timestamp, vals, cnames, ta.meta)
         end # function
     end # eval
 end # loop
 
-# Int,Float64 <--> TimeArray
-for op in COMPARE_DOTONLY 
+# Boolean ND TimeArray <--> Boolean ND TimeArray
+# Doesn't support broadcasting since it isn't supported by Base either
+for op in BOOLEAN_OPS
     @eval begin
-        function ($op){T,N}(var::Union(Int,Float64), ta::TimeArray{T,N})
-          cname  = [ta.colnames[1][1:2] *  string($op) *  string(var)]
-          vals   = Array(Bool, length(ta))
-          for i in 1:length(vals)
-              vals[i] = ($op)(var, ta.values[i])
-          end
-          TimeArray(ta.timestamp, vals, cname, ta.meta)
+        function ($op){N}(ta1::TimeArray{Bool,N}, ta2::TimeArray{Bool,N})
+            # test column count matches
+            length(ta1.colnames) == length(ta2.colnames) ?
+              ncols=length(ta1.colnames) :
+              error("arrays must have the same number of columns")
+            # test metadata matches
+            ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
+            cnames = [ta1.colnames[i]*string($op)*ta2.colnames[i] for i=1:ncols]
+            idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
+            # obtain shared timestamp
+            tstamp = ta1[idx1].timestamp
+            # retrieve values that match the Int array matching dates
+            vals1  = ta1[idx1].values
+            vals2  = ta2[idx2].values
+            vals = ($op)(vals1, vals2)
+            TimeArray(tstamp, vals, cnames, meta)
         end # function
     end # eval
 end # loop

--- a/src/split.jl
+++ b/src/split.jl
@@ -42,7 +42,7 @@ end
 ###### findwhen #################
 
 function findwhen(ta::TimeArray{Bool,1})
-    tstamps = [Date(1,1,1):Year(1):Date(sum(ta.values),1,1)]
+    tstamps = collect(Date(1,1,1):Year(1):Date(sum(ta.values),1,1))
     j = 1
     for i in 1:length(ta)
         if ta.values[i]

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -7,12 +7,12 @@ abstract AbstractTimeSeries
 immutable TimeArray{T,N,M} <: AbstractTimeSeries
 
     timestamp::Union(Vector{Date}, Vector{DateTime})
-    values::Array{T,N}
+    values::AbstractArray{T,N}
     colnames::Vector{UTF8String}
     meta::M
 
     function TimeArray(timestamp::Union(Vector{Date}, Vector{DateTime}),
-                       values::Array{T,N}, 
+                       values::AbstractArray{T,N},
                        colnames::Vector{UTF8String},
                        meta::M)
                            nrow, ncol = size(values, 1), size(values, 2)
@@ -26,12 +26,12 @@ immutable TimeArray{T,N,M} <: AbstractTimeSeries
     end
 end
 
-TimeArray{T,N,S<:String,M}(d::Union(Vector{Date}, Vector{DateTime}), v::Array{T,N}, c::Vector{S}, m::M) = TimeArray{T,N,M}(d,v,map(utf8,c),m)
-TimeArray{T,N,S<:String,M}(d::Union(Date, DateTime), v::Array{T,N}, c::Array{S,1}, m::M) = TimeArray([d],v,map(utf8,c),m)
+TimeArray{T,N,S<:String,M}(d::Union(Vector{Date}, Vector{DateTime}), v::AbstractArray{T,N}, c::Vector{S}, m::M) = TimeArray{T,N,M}(d,v,map(utf8,c),m)
+TimeArray{T,N,S<:String,M}(d::Union(Date, DateTime), v::AbstractArray{T,N}, c::Vector{S}, m::M) = TimeArray([d],v,map(utf8,c),m)
 
 # when no meta is provided
-TimeArray{T,N}(d::Union(Vector{Date}, Vector{DateTime}), v::Array{T,N}, c) = TimeArray(d,v,c,Nothing)
-TimeArray{T,N}(d::Union(Date, DateTime), v::Array{T,N}, c) = TimeArray([d],v,c,Nothing)
+TimeArray{T,N}(d::Union(Vector{Date}, Vector{DateTime}), v::AbstractArray{T,N}, c) = TimeArray(d,v,c,Nothing)
+TimeArray{T,N}(d::Union(Date, DateTime), v::AbstractArray{T,N}, c) = TimeArray([d],v,c,Nothing)
 
 ###### conversion ###############
 

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -3,61 +3,61 @@ using MarketData
 facts("time series methods") do
 
     context("lag takes previous day and timestamps it to next day") do
-        @fact lag(cl).values[1]    --> roughly(111.94, atol=.01) 
+        @fact lag(cl).values[1]    --> roughly(111.94, atol=.01)
         @fact lag(cl).timestamp[1] --> Date(2000,1,4)
     end
-  
+
     context("lag accepts kwarg") do
         @fact lag(cl, period=9).timestamp[1] --> Date(2000,1,14)
     end
-  
+
     context("lag operates on 2d arrays") do
         @fact lag(ohlc, period=9).timestamp[1] --> Date(2000,1,14)
     end
-  
+
     context("lag returns 1d from 1d time arrays") do
         @fact ndims(lag(cl).values) --> 1
     end
-  
+
     context("lag returns 2d from 2d time arrays") do
         @fact ndims(lag(ohlc).values) --> 2
     end
-  
+
     context("lead takes next day and timestamps it to current day") do
-        @fact lead(cl).values[1]    --> roughly(102.5, atol=.1) 
+        @fact lead(cl).values[1]    --> roughly(102.5, atol=.1)
         @fact lead(cl).timestamp[1] --> Date(2000,1,3)
     end
-  
+
     context("lead accepts kwarg") do
-        @fact lead(cl, period=9).values[1]    --> 100.44 
+        @fact lead(cl, period=9).values[1]    --> 100.44
         @fact lead(cl, period=9).timestamp[1] --> Date(2000,1,3)
     end
-  
+
     context("lead operates on 2d arrays") do
         @fact lead(ohlc, period=9).timestamp[1] --> Date(2000,1,3)
     end
-  
+
     context("lead returns 1d from 1d time arrays") do
         @fact ndims(lead(cl).values) --> 1
     end
-  
+
     context("lead returns 2d from 2d time arrays") do
         @fact ndims(lead(ohlc).values) --> 2
     end
-  
+
     context("correct simple return value") do
         @fact percentchange(cl).values[1] --> roughly((102.5-111.94)/111.94, atol=.01)
     end
-  
+
     context("correct log return value") do
         @fact percentchange(cl, method="log").values[1] --> roughly(log(102.5) - log(111.94), atol=.01)
     end
-  
+
     context("moving supplies correct window length") do
         @fact moving(cl, mean, 10).values[1]    --> roughly(sum(cl.values[1:10])/10, atol=.01)
         @fact moving(cl, mean, 10).timestamp[1] --> Date(2000,1,14)
     end
-   
+
     context("upto method accumulates") do
         @fact upto(cl, sum).values[10]    --> roughly(sum(cl.values[1:10]), atol=.01)
         @fact upto(cl, mean).values[10]   --> roughly(sum(cl.values[1:10])/10, atol=.01)
@@ -67,79 +67,215 @@ end
 
 facts("base element-wise operators on TimeArray values") do
 
-    context("correct alignment and operation between two TimeVectors") do
-        @fact (cl .+ op).values[1]           --> roughly(216.82, atol=.01)
-        @fact (cl .- op).values[1]           --> roughly(7.06, atol=.01)
-        @fact (cl .* op).values[1]           --> roughly(11740.2672, atol=.0001)
-        @fact (cl ./ op).values[1]           --> roughly(1.067315027)
-    end
-
     context("only values on intersecting Dates computed") do
-        @fact (cl[1:2] ./ op[2:3]).values[1] --> roughly(0.94688222) 
+        @fact (cl[1:2] ./ op[2:3]).values[1] --> roughly(0.94688222)
         @fact (cl[1:4] .+ op[4:7]).values[1] --> roughly(201.12, atol=.01)
         @fact length(cl[1:2] ./ op[2:3])     --> 1
         @fact length(cl[1:4] .+ op[4:7])     --> 1
     end
 
-    context("correct dot operation between TimeVectors values and Int/Float64 and viceversa") do
+    context("correct unary operation on TimeArray values") do
+        @fact (+cl).values[1]  --> cl.values[1]
+        @fact (-cl).values[1]  --> -cl.values[1]
+        @fact (!(cl .== op)).values[1]  --> true
+        @fact (+ohlc).values[1,:]  --> ohlc.values[1,:]
+        @fact (-ohlc).values[1,:]  --> -(ohlc.values[1,:])
+        @fact (!(ohlc .== ohlc)).values[1,1]  --> false
+    end
+
+    context("correct dot operation between TimeArray values and Int/Float and viceversa") do
         @fact (cl .- 100).values[1] --> roughly(11.94, atol=.01)
         @fact (cl .+ 100).values[1] --> roughly(211.94, atol=.01)
         @fact (cl .* 100).values[1] --> roughly(11194, atol=1)
         @fact (cl ./ 100).values[1] --> roughly(1.1194, atol=.0001)
         @fact (cl .^ 2).values[1]   --> roughly(12530.5636, atol=.0001)
+        @fact (cl .% 2).values[1]   --> cl.values[1] % 2
         @fact (100 .- cl).values[1] --> roughly(-11.94, atol=.01)
         @fact (100 .+ cl).values[1] --> roughly(211.94, atol=.01)
         @fact (100 .* cl).values[1] --> roughly(11194, atol=.01)
         @fact (100 ./ cl).values[1] --> roughly(0.8933357155619082)
         @fact (2 .^ cl).values[1]   --> 4980784073277740581384811358191616
+        @fact (2 .% cl).values[1]   --> 2
+        @fact (ohlc .- 100).values[1,:] --> ohlc.values[1,:] .- 100
+        @fact (ohlc .+ 100).values[1,:] --> ohlc.values[1,:] .+ 100
+        @fact (ohlc .* 100).values[1,:] --> ohlc.values[1,:] .* 100
+        @fact (ohlc ./ 100).values[1,:] --> ohlc.values[1,:] ./ 100
+        @fact (ohlc .^ 2).values[1,:]   --> ohlc.values[1,:] .^ 2
+        @fact (ohlc .% 2).values[1,:]   --> ohlc.values[1,:] .% 2
+        @fact (100 .- ohlc).values[1,:] --> 100 .- ohlc.values[1,:]
+        @fact (100 .+ ohlc).values[1,:] --> 100 .+ ohlc.values[1,:]
+        @fact (100 .* ohlc).values[1,:] --> 100 .* ohlc.values[1,:]
+        @fact (100 ./ ohlc).values[1,:] --> 100 ./ ohlc.values[1,:]
+        @fact (2 .^ ohlc).values[1,:]   --> 2 .^ ohlc.values[1,:]
+        @fact (2 .% ohlc).values[1,:]   --> 2 .% ohlc.values[1,:]
     end
 
-    context("element-wise mathematical operations between 2d time array and 1d time array") do
-        @fact (ohlc .+ cl).values[1,1] --> roughly(216.82, atol=.01)
-        @fact (ohlc .+ cl).values[1,2] --> roughly(224.44, atol=.01)
-        @fact (ohlc .* cl).values[1,1] --> roughly(11740.2672, atol=.0001)
-        @fact (ohlc .* cl).values[1,2] --> roughly(12593.25, atol=.01)
+    context("correct non-dot operation between TimeArray values and Int/Float and viceversa") do
+        @fact (cl - 100).values[1] --> roughly(11.94, atol=0.1)
+        @fact (cl + 100).values[1] --> roughly(211.94, atol=0.1)
+        @fact (cl * 100).values[1] --> roughly(11194, atol=0.1)
+        @fact (cl / 100).values[1] --> roughly(1.1194, atol=0.001)
+        @fact (cl % 2).values[1]   -->  cl.values[1] % 2
+        # not supported by Base - reserved for square matrix multiplication
+        @fact_throws (cl ^ 2).values[1]
+        @fact (100 - cl).values[1] --> roughly(-11.94, atol=0.1)
+        @fact (100 + cl).values[1] --> roughly(211.94, atol=0.1)
+        @fact (100 * cl).values[1] --> roughly(11194, atol=0.1)
+        # not supported by Base - confusion with matrix inverse
+        @fact_throws (100 / cl).values
+        # not supported by Base
+        @fact_throws (2 ^ cl).values
+        @fact (2 % cl).values[1] --> 2 % cl.values[1]
+        @fact (ohlc - 100).values[1,:] --> ohlc.values[1,:] - 100
+        @fact (ohlc + 100).values[1,:] --> ohlc.values[1,:] + 100
+        @fact (ohlc * 100).values[1,:] --> ohlc.values[1,:] * 100
+        @fact (ohlc / 100).values[1,:] --> ohlc.values[1,:] / 100
+        # not supported by Base - reserved for square matrix multiplication
+        @fact_throws (ohlc ^ 2).values[1,:]
+        @fact (ohlc % 2).values[1,:] --> ohlc.values[1,:] % 2
+        @fact (100 - ohlc).values[1,:] --> 100 - ohlc.values[1,:]
+        @fact (100 + ohlc).values[1,:] --> 100 + ohlc.values[1,:]
+        @fact (100 * ohlc).values[1,:] --> 100 * ohlc.values[1,:]
+        # not supported by Base - confusion with matrix inverse
+        @fact_throws (100 / ohlc).values[1,:]
+        # not supported by Base
+        @fact_throws (2 ^ ohlc).values[1,:]
+        @fact (2 % ohlc).values[1,:] --> 2 % ohlc.values[1,:]
     end
 
-    context("correct non-dot operation between TimeVectors values and Int/Float64 and viceversa") do
-        @fact (cl - 100).values[1] --> roughly(11.94, atol=.01)
-        @fact (cl + 100).values[1] --> roughly(211.94, atol=.01)
-        @fact (cl * 100).values[1] --> roughly(11194, atol=1)
-        @fact (cl / 100).values[1] --> roughly(1.1194, atol=.01)
-        @fact (100 - cl).values[1] --> roughly(-11.94, atol=.01)
-        @fact (100 + cl).values[1] --> roughly(211.94, atol=.01)
-        @fact (100 * cl).values[1] --> roughly(11194, atol=1)
-        @fact_throws (100 / cl).values[1] # related to base not supporting this 
+    context("correct mathematical operations between two same-column-count TimeArrays") do
+        @fact (cl .+ op).values[1]      --> roughly(216.82, atol=.01)
+        @fact (cl .- op).values[1]      --> roughly(7.06, atol=.01)
+        @fact (cl .* op).values[1]      --> roughly(11740.2672, atol=0.0001)
+        @fact (cl ./ op).values[1]      --> roughly(1.067315, atol=0.001)
+        @fact (cl .% op).values         --> cl.values .% op.values
+        @fact (cl .^ op).values         --> cl.values .^ op.values
+        @fact (ohlc .+ ohlc).values     --> ohlc.values .+ ohlc.values
+        @fact (ohlc .- ohlc).values     --> ohlc.values .- ohlc.values
+        @fact (ohlc .* ohlc).values     --> ohlc.values .* ohlc.values
+        @fact (ohlc ./ ohlc).values     --> ohlc.values ./ ohlc.values
+        @fact (ohlc .% ohlc).values     --> ohlc.values .% ohlc.values
+        @fact (ohlc .^ ohlc).values     --> ohlc.values .^ ohlc.values
     end
 
-    context("correct operation between two TimeVectors values returns bool for comparisons") do
-        @fact (cl .> op).values[1]  --> true
-        @fact (cl .< op).values[1]  --> false
-        @fact (cl .<= op).values[1] --> false
-        @fact (cl .>= op).values[1] --> true
-        @fact (cl .== op).values[1] --> false
+    context("correct broadcasted mathematical operations between different-column-count TimeArrays") do
+        @fact (ohlc .+ cl).values --> ohlc.values .+ cl.values
+        @fact (ohlc .- cl).values --> ohlc.values .- cl.values
+        @fact (ohlc .* cl).values --> ohlc.values .* cl.values
+        @fact (ohlc ./ cl).values --> ohlc.values ./ cl.values
+        @fact (ohlc .% cl).values --> ohlc.values .% cl.values
+        @fact (ohlc .^ cl).values --> ohlc.values .^ cl.values
+        @fact (cl .+ ohlc).values --> cl.values .+ ohlc.values
+        @fact (cl .- ohlc).values --> cl.values .- ohlc.values
+        @fact (cl .* ohlc).values --> cl.values .* ohlc.values
+        @fact (cl ./ ohlc).values --> cl.values ./ ohlc.values
+        @fact (cl .% ohlc).values --> cl.values .% ohlc.values
+        @fact (cl .^ ohlc).values --> cl.values .^ ohlc.values
+        @fact_throws (ohlc["Open", "Close"] .+ ohlc) # One array must have a single column
     end
 
-    context("correct operation between TimeVectors values and Int/Float64 (and viceversa) returns bool for comparison") do
+    context("correct comparison operations between TimeArray values and Int/Float (and viceversa)") do
         @fact (cl .> 111.94).values[1]  --> false
         @fact (cl .< 111.94).values[1]  --> false
         @fact (cl .>= 111.94).values[1] --> true
         @fact (cl .<= 111.94).values[1] --> true
         @fact (cl .== 111.94).values[1] --> true
+        @fact (cl .!= 111.94).values[1] --> false
         @fact (111.94 .> cl).values[1]  --> false
         @fact (111.94 .< cl).values[1]  --> false
         @fact (111.94 .>= cl).values[1] --> true
         @fact (111.94 .<= cl).values[1] --> true
         @fact (111.94 .== cl).values[1] --> true
+        @fact (111.94 .!= cl).values[1] --> false
+        @fact (ohlc .> 111.94).values[1,:]  --> [false true false false]
+        @fact (ohlc .< 111.94).values[1,:]  --> [true false true false]
+        @fact (ohlc .>= 111.94).values[1,:] --> [false true false true]
+        @fact (ohlc .<= 111.94).values[1,:] --> [true false true true]
+        @fact (ohlc .== 111.94).values[1,:] --> [false false false true]
+        @fact (ohlc .!= 111.94).values[1,:] --> [true true true false]
+        @fact (111.94 .> ohlc).values[1,:]  --> [true false true false]
+        @fact (111.94 .< ohlc).values[1,:]  --> [false true false false]
+        @fact (111.94 .>= ohlc).values[1,:] --> [true false true true]
+        @fact (111.94 .<= ohlc).values[1,:] --> [false true false true]
+        @fact (111.94 .== ohlc).values[1,:] --> [false false false true]
+        @fact (111.94 .!= ohlc).values[1,:] --> [true true true false]
     end
+
+    context("correct comparison operations between TimeArray values and Bool (and viceversa)") do
+        @fact ((cl .> 111.94) .== true).values[1] --> false
+        @fact ((cl .> 111.94) .!= true).values[1] --> true
+        @fact (true .== (cl .> 111.94)).values[1] --> false
+        @fact (true .!= (cl .> 111.94)).values[1] --> true
+        @fact ((ohlc .> 111.94).== true).values[1,:] --> [false true false false]
+        @fact ((ohlc .> 111.94).!= true).values[1,:] --> [true false true true]
+        @fact (true .== (ohlc .> 111.94)).values[1,:] --> [false true false false]
+        @fact (true .!= (ohlc .> 111.94)).values[1,:] --> [true false true true]
+    end
+
+    context("correct comparison operations between same-column-count TimeArrays") do
+        @fact (cl .> op).values[1]  --> true
+        @fact (cl .< op).values[1]  --> false
+        @fact (cl .<= op).values[1] --> false
+        @fact (cl .>= op).values[1] --> true
+        @fact (cl .== op).values[1] --> false
+        @fact (cl .!= op).values[1] --> true
+        @fact (ohlc .> ohlc).values[1,:]  --> [false false false false]
+        @fact (ohlc .< ohlc).values[1,:]  --> [false false false false]
+        @fact (ohlc .<= ohlc).values[1,:] --> [true true true true]
+        @fact (ohlc .>= ohlc).values[1,:] --> [true true true true]
+        @fact (ohlc .== ohlc).values[1,:] --> [true true true true]
+        @fact (ohlc .!= ohlc).values[1,:] --> [false false false false]
+    end
+
+    context("correct comparison operations between different-column-count TimeArrays") do
+        @fact (ohlc .> cl).values  --> ohlc.values .> cl.values
+        @fact (ohlc .< cl).values  --> ohlc.values .< cl.values
+        @fact (ohlc .>= cl).values --> ohlc.values .>= cl.values
+        @fact (ohlc .<= cl).values --> ohlc.values .<= cl.values
+        @fact (ohlc .== cl).values --> ohlc.values .== cl.values
+        @fact (ohlc .!= cl).values --> ohlc.values .!= cl.values
+        @fact (cl .> ohlc).values  --> cl.values .> ohlc.values
+        @fact (cl .< ohlc).values  --> cl.values .< ohlc.values
+        @fact (cl .>= ohlc).values --> cl.values .>= ohlc.values
+        @fact (cl .<= ohlc).values --> cl.values .<= ohlc.values
+        @fact (cl .== ohlc).values --> cl.values .== ohlc.values
+        @fact (cl .!= ohlc).values --> cl.values .!= ohlc.values
+        @fact_throws (ohlc["Open", "Close"] .== ohlc) # One array must have a single column
+    end
+
+    context("correct bitwise elementwise operations between bool and TimeArrays' values") do
+        @fact ((cl .> 100) & true).values[1] --> true
+        @fact ((cl .> 100) | true).values[1] --> true
+        @fact ((cl .> 100) $ true).values[1] --> false
+        @fact (false & (cl .> 100)).values[1] --> false
+        @fact (false | (cl .> 100)).values[1] --> true
+        @fact (false $ (cl .> 100)).values[1] --> true
+        @fact ((ohlc .> 100) & true).values[4,:] --> [true true false false]
+        @fact ((ohlc .> 100) | true).values[4,:] --> [true true true true]
+        @fact ((ohlc .> 100) $ true).values[4,:] --> [false false true true]
+        @fact (false & (ohlc .> 100)).values[4,:] --> [false false false false]
+        @fact (false | (ohlc .> 100)).values[4,:] --> [true true false false]
+        @fact (false $ (ohlc .> 100)).values[4,:] --> [true true false false]
+      end
+
+    context("correct bitwise elementwise operations between same-column-count TimeArrays' boolean values") do
+        @fact ((cl .> 100) & (cl .< 120)).values[1] --> true
+        @fact ((cl .> 100) | (cl .< 120)).values[1] --> true
+        @fact ((cl .> 100) $ (cl .< 120)).values[1] --> false
+        @fact ((ohlc .> 100) & (ohlc .< 120)).values[4,:] --> [true true false false]
+        @fact ((ohlc .> 100) | (ohlc .< 120)).values[4,:] --> [true true true true]
+        @fact ((ohlc .> 100) $ (ohlc .< 120)).values[4,:] --> [false false true true]
+        @fact_throws ((ohlc .> 100) $ (cl.< 120)) # Bitwise broadcasting not supported by Base
+    end
+
 end
 
 facts("basecall works with Base methods") do
-  
+
     context("cumsum works") do
         @fact basecall(cl, cumsum).values[2] --> cl.values[1] + cl.values[2]
     end
-    
+
     context("log works") do
         @fact basecall(cl, log).values[2] --> log(cl.values[2])
     end


### PR DESCRIPTION
A master-compatible version of https://github.com/JuliaStats/TimeSeries.jl/pull/197 - switches the value container from `Array` to `AbstractArray` and implements `!`, `~`, `&`, `|`, `$`, `%`, `!==`, and unary `+` and `-`, with appropriate documentation.