### PR TITLE
Indexing/lookup enhancements

### DIFF
--- a/src/split.jl
+++ b/src/split.jl
@@ -27,31 +27,11 @@ end
 
 ###### findall ##################
 
-function findall(ta::TimeArray{Bool,1})
-    rownums = round(Int64, zeros(sum(ta.values)))
-    j = 1
-    for i in 1:length(ta)
-        if ta.values[i]
-            rownums[j] = i
-            j+=1
-        end
-    end
-    rownums
-end
- 
+findall(ta::TimeArray{Bool,1}) = find(ta.values)
+
 ###### findwhen #################
 
-function findwhen(ta::TimeArray{Bool,1})
-    tstamps = collect(Date(1,1,1):Year(1):Date(sum(ta.values),1,1))
-    j = 1
-    for i in 1:length(ta)
-        if ta.values[i]
-            tstamps[j] = ta.timestamp[i]
-            j+=1
-        end
-    end
-    tstamps
-end
+findwhen(ta::TimeArray{Bool,1}) = ta.timestamp[find(ta.values)]
 
 ###### element wrapers ###########
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -1,6 +1,6 @@
 ###### type definition ##########
 
-import Base: convert, length, show, getindex, start, next, done, isempty
+import Base: convert, length, show, getindex, start, next, done, isempty, endof
 
 abstract AbstractTimeSeries
 
@@ -188,22 +188,21 @@ function getindex{T,N}(ta::TimeArray{T,N}, d::Union(Date, DateTime))
     end
 end
  
-# range of dates
+# multiple dates
 function getindex{T,N}(ta::TimeArray{T,N}, dates::Union(Vector{Date}, Vector{DateTime}))
-    counter = Int[]
-  #  counter = int(zeros(length(dates)))
-    for i in 1:length(dates)
-        if findfirst(ta.timestamp, dates[i]) != 0
-        #counter[i] = findfirst(ta.timestamp, dates[i])
-            push!(counter, findfirst(ta.timestamp, dates[i]))
-        end
-    end
+    dates = sort(dates)
+    counter, _ = overlaps(ta.timestamp, dates)
     ta[counter]
-end
+end #getindex
 
 function getindex{T,N}(ta::TimeArray{T,N}, r::Union(StepRange{Date}, StepRange{DateTime})) 
-    ta[[r;]]
+    ta[collect(r)]
 end
+
+getindex{T,N}(ta::TimeArray{T,N}, k::TimeArray{Bool,1}) = ta[findwhen(k)]
 
 # day of week
 # getindex{T,N}(ta::TimeArray{T,N}, d::DAYOFWEEK) = ta[dayofweek(ta.timestamp) .== d]
+
+# Define end keyword
+endof(ta::TimeArray) = length(ta.timestamp)

--- a/test/split.jl
+++ b/test/split.jl
@@ -2,15 +2,15 @@ using MarketData
 
 facts("find methods") do
 
-  context("findall returns correct row numbers array") do
-      @fact cl[findall(cl .> op)].timestamp[1] --> Date(2000,1,3)
-      @fact length(findall(cl .> op))          --> 244
-  end
+    context("findall returns correct row numbers array") do
+        @fact cl[findall(cl .> op)].timestamp[1] --> Date(2000,1,3)
+        @fact length(findall(cl .> op))          --> 244
+    end
 
-  context("findwhen returns correct Dates array") do
-      @fact findwhen(cl .> op)[1]      --> Date(2000,1,3)
-      @fact length(findwhen(cl .> op)) --> 244 
-  end
+    context("findwhen returns correct Dates array") do
+       @fact findwhen(cl .> op)[2]      --> Date(2000,1,5)
+       @fact length(findwhen(cl .> op)) --> 244
+    end
 end
 
 facts("split date operations") do

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -44,8 +44,20 @@ facts("conversion methods") do
     end
 end
 
-facts("getindex methods") do
-  
+facts("ordered collection methods") do
+
+    context("iterator protocol is valid") do
+      @fact op --> not(isempty)
+      @fact op[op .< 0] --> isempty
+      @fact start(op) --> 1
+      @fact next(op, 1) --> ((op.timestamp[1], op.values[1,:]), 2)
+      @fact done(op, length(op)+1) --> true
+    end
+
+    context("end keyword returns correct index") do
+      @fact ohlc[end].timestamp[1] --> ohlc.timestamp[end]
+    end
+
     context("getindex on single Int and Date") do
         @fact ohlc[1].timestamp              --> [Date(2000,1,3)]
         @fact ohlc[Date(2000,1,3)].timestamp --> [Date(2000,1,3)]
@@ -87,4 +99,11 @@ facts("getindex methods") do
         @fact isa(cl[1], TimeArray{Float64,1})   --> true
         @fact isa(cl[1:2], TimeArray{Float64,1}) --> true
     end
+
+    context("getindex on a 1d Boolean TimeArray returns appropriate rows") do
+        @fact ohlc[op .> cl][2].values --> ohlc[4].values
+        @fact ohlc[op[300:end] .> cl][2].timestamp --> ohlc[303].timestamp
+        @fact_throws ohlc[merge(op.>cl, op.<cl)] # MethodError, Bool must be 1D-TimeArray
+    end
+
 end


### PR DESCRIPTION
A bit of a grab bag of minor enhancements, generally indexing-related. Most notable is adding support for the `end` keyword in indices, and allowing specifying indices to get via a `TimeArray{Bool,1}`. To go along with that is a speedup for Date-based lookups, from polynomial to linear time:

Current master:
```julia
julia> @time AAPL[findwhen((BA["Close"] .> BA["Open"]) | (CAT["Close"] .> CAT["Open"]))]
  0.224620 seconds (730.40 k allocations: 42.386 MB, 5.90% gc time)
```
This PR:
```julia
julia> @time AAPL[(BA["Close"] .> BA["Open"]) | (CAT["Close"] .> CAT["Open"])]
  0.124473 seconds (668.16 k allocations: 41.726 MB, 7.25% gc time)
```