### PR TITLE
WIP: Adding TimeType type parameter

### DIFF
--- a/src/combine.jl
+++ b/src/combine.jl
@@ -29,7 +29,7 @@ end
 
 # collapse ######################
 
-function collapse{T,N}(ta::TimeArray{T,N}, f::Function; period::Function=week)
+function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=week)
   
     w = [period(ta.timestamp[t]) for t in 1:length(ta)] # get weekly id from entire array
     z = Int[]; j = 1
@@ -48,7 +48,7 @@ function collapse{T,N}(ta::TimeArray{T,N}, f::Function; period::Function=week)
     push!(z, z[length(z)] + 1)  
    
     # pre-allocate timestamp and value arrays
-    tstamps = [(Date(1,1,1):Year(1):Date(maximum(z),1,1));]
+    tstamps = Array{D}(maximum(z))
     vals    = zeros(maximum(z)) # number of unique periods
     #replace their values except for the last row 
     for i = 1:maximum(z)-1  # iterate over period ID groupings

--- a/src/split.jl
+++ b/src/split.jl
@@ -17,15 +17,15 @@ end
  
 # from, to ######################
  
-function from{T,N,D}(ta::TimeArray{T,N,D}, d::D)
-    d_idx = searchsortedfirst(ta.timestamp, d)
-    d_idx < length(ta)+1 ? ta[d_idx:end] : ta
-end 
+from{T,N,D}(ta::TimeArray{T,N,D}, d::D) =
+    d < ta.timestamp[1] ? ta :
+    d > ta.timestamp[end] ? ta[1:0] :
+    ta[searchsortedfirst(ta.timestamp, d):end]
 
-function to{T,N,D}(ta::TimeArray{T,N,D}, d::D)
-    d_idx = searchsortedlast(ta.timestamp, d)
-    d_idx > 0 ? ta[1:d_idx] : ta
-end 
+to{T,N,D}(ta::TimeArray{T,N,D}, d::D) =
+    d < ta.timestamp[1] ? ta[1:0] :
+    d > ta.timestamp[end] ? ta :
+    ta[1:searchsortedlast(ta.timestamp, d)]
 
 ###### findall ##################
 

--- a/src/split.jl
+++ b/src/split.jl
@@ -17,12 +17,14 @@ end
  
 # from, to ######################
  
-function from{T,N}(ta::TimeArray{T,N}, y::Int, m::Int, d::Int)
-    ta[Date(y,m,d):last(ta.timestamp)]
+function from{T,N,D}(ta::TimeArray{T,N,D}, d::D)
+    d_idx = searchsortedfirst(ta.timestamp, d)
+    d_idx < length(ta)+1 ? ta[d_idx:end] : ta
 end 
 
-function to{T,N}(ta::TimeArray{T,N}, y::Int, m::Int, d::Int)
-    ta[ta.timestamp[1]:Date(y,m,d)]
+function to{T,N,D}(ta::TimeArray{T,N,D}, d::D)
+    d_idx = searchsortedlast(ta.timestamp, d)
+    d_idx > 0 ? ta[1:d_idx] : ta
 end 
 
 ###### findall ##################

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -4,14 +4,14 @@ import Base: convert, length, show, getindex, start, next, done, isempty, endof
 
 abstract AbstractTimeSeries
 
-immutable TimeArray{T,N,M} <: AbstractTimeSeries
+immutable TimeArray{T, N, D<:TimeType, M} <: AbstractTimeSeries
 
-    timestamp::Union{Vector{Date}, Vector{DateTime}}
+    timestamp::Vector{D}
     values::AbstractArray{T,N}
     colnames::Vector{UTF8String}
     meta::M
 
-    function TimeArray(timestamp::Union{Vector{Date}, Vector{DateTime}},
+    function TimeArray(timestamp::Vector{D},
                        values::AbstractArray{T,N},
                        colnames::Vector{UTF8String},
                        meta::M)
@@ -26,12 +26,12 @@ immutable TimeArray{T,N,M} <: AbstractTimeSeries
     end
 end
 
-TimeArray{T,N,S<:AbstractString,M}(d::Union{Vector{Date}, Vector{DateTime}}, v::AbstractArray{T,N}, c::Vector{S}, m::M) = TimeArray{T,N,M}(d,v,map(utf8,c),m)
-TimeArray{T,N,S<:AbstractString,M}(d::Union{Date, DateTime}, v::AbstractArray{T,N}, c::Vector{S}, m::M) = TimeArray([d],v,map(utf8,c),m)
+TimeArray{T,N,D<:TimeType,S<:AbstractString,M}(d::Vector{D}, v::AbstractArray{T,N}, c::Vector{S}, m::M) = TimeArray{T,N,D,M}(d,v,map(utf8,c),m)
+TimeArray{T,N,D<:TimeType,S<:AbstractString,M}(d::D, v::AbstractArray{T,N}, c::Vector{S}, m::M) = TimeArray([d],v,map(utf8,c),m)
 
 # when no meta is provided
-TimeArray{T,N}(d::Union{Vector{Date}, Vector{DateTime}}, v::AbstractArray{T,N}, c) = TimeArray(d,v,c,nothing)
-TimeArray{T,N}(d::Union{Date, DateTime}, v::AbstractArray{T,N}, c) = TimeArray([d],v,c,nothing)
+TimeArray{T,N,D<:TimeType}(d::Vector{D}, v::AbstractArray{T,N}, c) = TimeArray(d,v,c,nothing)
+TimeArray{T,N,D<:TimeType}(d::D, v::AbstractArray{T,N}, c) = TimeArray([d],v,c,nothing)
 
 ###### conversion ###############
 
@@ -43,9 +43,7 @@ convert(x::TimeArray{Bool,2}) = convert(TimeArray{Float64,2}, x::TimeArray{Bool,
 
 ###### length ###################
 
-function length(ata::AbstractTimeSeries)
-    length(ata.timestamp)
-end
+length(ata::AbstractTimeSeries) = length(ata.timestamp)
 
 ###### iterator protocol #########
 
@@ -136,70 +134,63 @@ end
 ###### getindex #################
 
 # single row
-function getindex{T,N}(ta::TimeArray{T,N}, n::Int)
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, n::Int)
     TimeArray(ta.timestamp[n], ta.values[n,:], ta.colnames, ta.meta)
 end
 
 # single row 1d
-function getindex{T}(ta::TimeArray{T,1}, n::Int)
+function getindex{T,D}(ta::TimeArray{T,1,D}, n::Int)
     TimeArray(ta.timestamp[n], ta.values[[n]], ta.colnames, ta.meta)
 end
 
 # range of rows
-function getindex{T,N}(ta::TimeArray{T,N}, r::UnitRange{Int})
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, r::UnitRange{Int})
     TimeArray(ta.timestamp[r], ta.values[r,:], ta.colnames, ta.meta)
 end
 
 # range of 1d rows
-function getindex{T}(ta::TimeArray{T,1}, r::UnitRange{Int})
+function getindex{T,D}(ta::TimeArray{T,1,D}, r::UnitRange{Int})
     TimeArray(ta.timestamp[r], ta.values[r], ta.colnames, ta.meta)
 end
 
 # array of rows
-function getindex{T,N}(ta::TimeArray{T,N}, a::Array{Int})
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, a::Vector{Int})
     TimeArray(ta.timestamp[a], ta.values[a,:], ta.colnames, ta.meta)
 end
 
 # array of 1d rows
-function getindex{T}(ta::TimeArray{T,1}, a::Array{Int})
+function getindex{T,D}(ta::TimeArray{T,1,D}, a::Vector{Int})
     TimeArray(ta.timestamp[a], ta.values[a], ta.colnames, ta.meta)
 end
 
 # single column by name 
-function getindex{T,N}(ta::TimeArray{T,N}, s::AbstractString)
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, s::AbstractString)
     n = findfirst(ta.colnames, s)
     TimeArray(ta.timestamp, ta.values[:, n], UTF8String[s], ta.meta)
 end
 
 # array of columns by name
-function getindex{T,N}(ta::TimeArray{T,N}, args::AbstractString...)
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, args::AbstractString...)
     ns = [findfirst(ta.colnames, a) for a in args]
     TimeArray(ta.timestamp, ta.values[:,ns], UTF8String[a for a in args], ta.meta)
 end
 
 # single date
-function getindex{T,N}(ta::TimeArray{T,N}, d::Union{Date, DateTime})
-    for i in 1:length(ta)
-        if [d] == ta[i].timestamp 
-            return ta[i] 
-        else 
-            nothing
-       end
-    end
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, d::D)
+    idx = findfirst(ta.timestamp, d)
+    idx > 0 ? ta[idx] : nothing
 end
  
 # multiple dates
-function getindex{T,N}(ta::TimeArray{T,N}, dates::Union{Vector{Date}, Vector{DateTime}})
+function getindex{T,N,D}(ta::TimeArray{T,N,D}, dates::Vector{D})
     dates = sort(dates)
-    counter, _ = overlaps(ta.timestamp, dates)
-    ta[counter]
+    idxs, _ = overlaps(ta.timestamp, dates)
+    ta[idxs]
 end #getindex
 
-function getindex{T,N}(ta::TimeArray{T,N}, r::Union{StepRange{Date}, StepRange{DateTime}}) 
-    ta[collect(r)]
-end
+getindex{T,N,D}(ta::TimeArray{T,N,D}, r::StepRange{D}) = ta[collect(r)]
 
-getindex{T,N}(ta::TimeArray{T,N}, k::TimeArray{Bool,1}) = ta[findwhen(k)]
+getindex{T,N,D}(ta::TimeArray{T,N,D}, k::TimeArray{Bool,1}) = ta[findwhen(k)]
 
 # day of week
 # getindex{T,N}(ta::TimeArray{T,N}, d::DAYOFWEEK) = ta[dayofweek(ta.timestamp) .== d]

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -177,8 +177,8 @@ end
 
 # single date
 function getindex{T,N,D}(ta::TimeArray{T,N,D}, d::D)
-    idx = findfirst(ta.timestamp, d)
-    idx > 0 ? ta[idx] : nothing
+    idxs = searchsorted(ta.timestamp, d)
+    length(idxs) == 1 ? ta[idxs[1]] : nothing
 end
  
 # multiple dates

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -37,11 +37,11 @@ facts("split operations preserve meta") do
     end
 
     context("from") do
-        @fact from(mdata, 2000,1,1).meta --> "Apple"
+        @fact from(mdata, Date(2000,1,1)).meta --> "Apple"
     end
   
     context("to") do
-        @fact to(mdata, 2000,1,1).meta --> "Apple"
+        @fact to(mdata, Date(2000,1,1)).meta --> "Apple"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using FactCheck
+using TimeSeries
+using Base.Dates
 
 include("timearray.jl")
 include("split.jl") 

--- a/test/split.jl
+++ b/test/split.jl
@@ -16,8 +16,8 @@ end
 facts("split date operations") do
 
     context("from and to correctly subset") do
-        @fact length(from(cl, 2001,12,28)) --> 2
-        @fact length(to(cl, 2000,1,4))     --> 2
+        @fact length(from(cl, Date(2001,12,28))) --> 2
+        @fact length(to(cl, Date(2000,1,4)))     --> 2
     end
 
     context("bydate methods correctly subset") do

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -73,11 +73,10 @@ facts("ordered collection methods") do
         @fact ohlc[Date(2000,1,3):Day(1):Date(2000,1,4)].timestamp --> [Date(2000,1,3), Date(2000,1,4)]
     end
   
-    # TODO get meaningful tests
     context("getindex on range of DateTime when only Date is in timestamp") do
-        @fact ohlc[DateTime(2000,1,3,0,0,0)].timestamp                                 --> [DateTime(2000,1,3,0,0,0)]
-        @fact ohlc[[DateTime(2000,1,3,0,0,0),DateTime(2000,1,14,0,0,0)]].timestamp     --> [DateTime(2000,1,3,0,0,0), DateTime(2000,1,14,0,0,0)]
-        @fact ohlc[DateTime(2000,1,3,0,0,0):Day(1):DateTime(2000,1,4,0,0,0)].timestamp --> [DateTime(2000,1,3,0,0,0), DateTime(2000,1,4,0,0,0)]
+        @fact_throws ohlc[DateTime(2000,1,3,0,0,0)]
+        @fact_throws ohlc[[DateTime(2000,1,3,0,0,0),DateTime(2000,1,14,0,0,0)]]
+        @fact_throws ohlc[DateTime(2000,1,3,0,0,0):Day(1):DateTime(2000,1,4,0,0,0)]
     end
   
     context("getindex on range of Date") do


### PR DESCRIPTION
As discussed in https://github.com/JuliaStats/TimeSeries.jl/issues/207, this would add a type parameter to `TimeArray` describing the type of the timestamps being used.

One question raised by the failing tests is, what to do with index lookups when the timestamp index passed in isn't the same type as the timestamps? Historically Date and DateTime have been used a bit interchangeably, but if we want to support other theoretical TimeTypes this may have to be revisited...

Also, the tests (for both master and this branch) started failing on me all of a sudden without `using` TimeSeries and Base.Dates in `runtests.jl`. I'm a bit puzzled because Travis didn't seem to have a problem with the same commits, and as far as I could tell was running the same versions of Julia, FactCheck, etc... Not sure what was up there, but I added in the necessary lines here.