### PR TITLE
WIP: Merge extensions

### DIFF
--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -9,8 +9,8 @@ using Base.Dates
 export TimeArray, AbstractTimeSeries,
        by, from, to, findwhen, findall, timestamp, values, colnames, meta,
        lag, lead, percentchange, moving, upto,
-       basecall,
-       merge, collapse,
+       basecall, uniformlyspaced, uniformlyspace,
+       merge, merge_left, collapse,
        readtimearray
 
 ###### include ##################

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -187,3 +187,22 @@ end
 ###### basecall #################
 
 basecall{T,N}(ta::TimeArray{T,N}, f::Function; cnames=ta.colnames) =  TimeArray(ta.timestamp, f(ta.values), cnames, ta.meta)
+
+###### uniform observations #####
+
+function uniformlyspaced(ta::TimeArray)
+    gap1 = ta.timestamp[2] - ta.timestamp[1]
+    i, n, is_uniform = 2, length(ta), true
+    while is_uniform & (i < n)
+        is_uniform = gap1 == (ta.timestamp[i+1] - ta.timestamp[i])
+        i += 1
+    end #while
+    return is_uniform
+end #uniformlyspaced
+
+function uniformlyspace(ta::TimeArray)
+    min_gap = minimum(ta.timestamp[2:end] - ta.timestamp[1:end-1])
+    newtimestamp = ta.timestamp[1]:min_gap:ta.timestamp[end]
+    emptyta = TimeArray(collect(newtimestamp), zeros(length(newtimestamp), 0), UTF8String[])
+    return merge_left(emptyta, ta)
+end #uniformlyspace

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -2,11 +2,9 @@ import Base: merge
 
 ###### merge ####################
 
-# used by merge method
-
 # thanks Tom Short @tshort for this implementation
 
-function merge{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; col_names=[""])
+function merge{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; col_names::Vector=[])
     # first test metadata matches
     ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
     # obtain unique indexes of when dates match
@@ -21,8 +19,9 @@ function merge{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; col_names=[""])
     # combine existing colnames
     cnames = vcat(ta1.colnames, ta2.colnames)
     # check if kwarg to over-ride simple vcat and then if colnames is valid length
-    size(col_names,1) == 1 ? cnames = cnames :       # kwarg not supplied
-    size(col_names,1) == size(vals,2) ? cnames = col_names : error("col_names supplied is not correct size")
+    length(col_names) == size(vals,2) ? cnames = col_names :
+        length(col_names) == 0 ? cnames = cnames : # kwarg not supplied
+        error("col_names supplied is not correct size")
     # put it all together
     TimeArray(tstamp, vals, cnames, meta)
 end

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -26,6 +26,26 @@ function merge{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; col_names::Vector=[])
     TimeArray(tstamp, vals, cnames, meta)
 end
 
+function merge_left{T}(ta1::TimeArray{T}, ta2::TimeArray{T}; col_names::Vector=[])
+    # first test metadata matches
+    ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
+    # obtain unique indexes of when dates match
+    new_idx2, old_idx2 = overlaps(ta1.timestamp, ta2.timestamp)
+    # retrieve values that match the Int array matching dates
+    right_vals = NaN * zeros(length(ta1), length(ta2.colnames))
+    right_vals[new_idx2, :]  = ta2.values[old_idx2, :]
+    # combine the values arrays
+    vals   = hcat(ta1.values, right_vals)
+    # combine existing colnames
+    cnames = vcat(ta1.colnames, ta2.colnames)
+    # check if kwarg to over-ride simple vcat and then if colnames is valid length
+    length(col_names) == size(vals,2) ? cnames = col_names :
+        length(col_names) == 0 ? cnames = cnames : # kwarg not supplied
+        error("col_names supplied is not correct size")
+    # put it all together
+    TimeArray(ta1.timestamp, vals, cnames, meta)
+end
+
 # collapse ######################
 
 function collapse{T,N}(ta::TimeArray{T,N}, f::Function; period::Function=week)

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -18,9 +18,7 @@ facts("merge works correctly") do
         @fact merge(cl,ohlc["High", "Low"], col_names=["a","b","c"]).colnames[3] --> "c"
         @fact merge(cl,op, col_names=["a","b"]).colnames[1]                      --> "a"
         @fact merge(cl,op, col_names=["a","b"]).colnames[2]                      --> "b"
-        @fact merge(cl,op, col_names=["a"]).colnames[1]                          --> "Close"
-        @fact merge(cl,op, col_names=["a"]).colnames[2]                          --> "Open"
-        @fact_throws merge(cl,op, col_names=["a","b","c"])
+        @fact_throws merge(cl,op, col_names=["a"])
         @fact_throws merge(cl,op, col_names=["a","b","c"])
     end
   


### PR DESCRIPTION
Eventually it would be good to have left, right, and outer merges/joins as well as the default inner merge - maybe once we have a better means of handling missing values though. I needed to induce equal spacing of observation rows and figured a left merge would be the cleanest way to do that, so implemented it and leave it here as a potential starting point if we want to come back to this somewhere down the road.

For reference, here's what the uniform spacing functions do:

```julia
julia> using TimeSeries
julia> using MarketData
julia> uniformlyspaced(cl)
false
julia> uniformlyspace(cl)[1:8]
8x1 TimeSeries.TimeArray{Float64,2,Void} 2000-01-03 to 2000-01-10

             Close     
2000-01-03 | 111.94    
2000-01-04 | 102.5     
2000-01-05 | 104.0     
2000-01-06 | 95.0      
⋮
2000-01-07 | 99.5      
2000-01-08 | NaN       
2000-01-09 | NaN       
2000-01-10 | 97.75
```