### PR TITLE
Fix BoundsError when calling show on empty TimeArray

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -68,17 +68,18 @@ function show{T,N}(io::IO, ta::TimeArray{T,N})
             intcatcher[c] = true
         end
     end
-    spacetime     = strwidth(string(ta.timestamp[1])) + 3
+    spacetime     = nrow > 0 ? strwidth(string(ta.timestamp[1])) + 3 : 3
     firstcolwidth = strwidth(ta.colnames[1])
     colwidth      = Int[]
-        for m in 1:ncol
-            T == Bool ?
-            push!(colwidth, max(strwidth(ta.colnames[m]), 5)) :
-            push!(colwidth, max(strwidth(ta.colnames[m]), strwidth(@sprintf("%.2f", maximum(ta.values[:,m]))) + DECIMALS - 2))
-        end
+    for m in 1:ncol
+        (T == Bool) || (nrow == 0) ?
+        push!(colwidth, max(strwidth(ta.colnames[m]), 5)) :
+        push!(colwidth, max(strwidth(ta.colnames[m]), strwidth(@sprintf("%.2f", maximum(ta.values[:,m]))) + DECIMALS - 2))
+    end
   
     # summary line
-    print(io, @sprintf("%dx%d %s %s to %s", nrow, ncol, typeof(ta), string(ta.timestamp[1]), string(ta.timestamp[nrow])))
+    @printf(io, "%dx%d %s", nrow, ncol, typeof(ta))
+    nrow > 0 && @printf(io, " %s to %s", string(ta.timestamp[1]), string(ta.timestamp[end]))
     println(io, "")
     println(io, "")
 
@@ -118,7 +119,7 @@ function show{T,N}(io::IO, ta::TimeArray{T,N})
         end
         println(io, "")
         end
-    else
+    elseif nrow > 0
         for i in 1:nrow
             print(io, ta.timestamp[i], " | ")
         for j in 1:ncol

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -107,3 +107,20 @@ facts("ordered collection methods") do
     end
 
 end
+
+facts("show method displays correctly") do
+
+    context("long TimeArray") do
+        @fact sprint(show, ohlc) --> "500x4 TimeSeries.TimeArray{Float64,2,Void} 2000-01-03 to 2001-12-31\n\n             Open      High      Low       Close     \n2000-01-03 | 104.88    112.5     101.69    111.94    \n2000-01-04 | 108.25    110.62    101.19    102.5     \n2000-01-05 | 103.75    110.56    103.0     104.0     \n2000-01-06 | 106.12    107.0     95.0      95.0      \n⋮\n2001-12-26 | 21.35     22.3      21.14     21.49     \n2001-12-27 | 21.58     22.25     21.58     22.07     \n2001-12-28 | 21.97     23.0      21.96     22.43     \n2001-12-31 | 22.51     22.66     21.83     21.9      \n"
+    end
+
+    context("short TimeArray") do
+        @fact sprint(show, ohlc[1:4]) --> "4x4 TimeSeries.TimeArray{Float64,2,Void} 2000-01-03 to 2000-01-06\n\n             Open      High      Low       Close     \n2000-01-03 | 104.88    112.5     101.69    111.94    \n2000-01-04 | 108.25    110.62    101.19    102.5     \n2000-01-05 | 103.75    110.56    103.0     104.0     \n2000-01-06 | 106.12    107.0     95.0      95.0      \n"
+    end 
+
+    context("empty TimeArray") do
+        @fact sprint(show, ohlc[1:0]) --> "0x4 TimeSeries.TimeArray{Float64,2,Void}\n\n   Open   High   Low    Close  \n"
+    end
+
+end
+


### PR DESCRIPTION
Also adds tests for `show`ing various lengths of TimeArray.

Example:

```julia
julia> using MarketData

julia> ohlc[1:0]
0x4 TimeSeries.TimeArray{Float64,2,Void}

   Open   High   Low    Close  

```
