### PR TITLE
Add common scalar->scalar math functions as unary operators

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,4 +1,9 @@
-UNARY = [:+, :-, :~, :!]
+UNARY = [:+, :-, :~, :!, :abs, :sign, :sqrt, :cbrt,
+          :log, :log2, :log10, :log1p,
+          :exp, :exp2, :exp10, :expm1,
+          :cos, :sin, :tan, :cosd, :sind, :tand,
+          :acos, :asin, :atan, :acosd, :asind, :atand
+        ]
 MATH_DOTONLY    = [:.+, :.-, :.*, :./, :.%, :.^]
 MATH_ALL        = [MATH_DOTONLY; [:+, :-, :*, :/, :%]]
 COMPARE_DOTONLY = [:.>, :.<, :.==, :.>=, :.<=, :.!=]

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -2,7 +2,8 @@ UNARY = [:+, :-, :~, :!, :abs, :sign, :sqrt, :cbrt,
           :log, :log2, :log10, :log1p,
           :exp, :exp2, :exp10, :expm1,
           :cos, :sin, :tan, :cosd, :sind, :tand,
-          :acos, :asin, :atan, :acosd, :asind, :atand
+          :acos, :asin, :atan, :acosd, :asind, :atand,
+          :isnan, :isinf
         ]
 MATH_DOTONLY    = [:.+, :.-, :.*, :./, :.%, :.^]
 MATH_ALL        = [MATH_DOTONLY; [:+, :-, :*, :/, :%]]

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -78,9 +78,14 @@ facts("base element-wise operators on TimeArray values") do
         @fact (+cl).values[1]  --> cl.values[1]
         @fact (-cl).values[1]  --> -cl.values[1]
         @fact (!(cl .== op)).values[1]  --> true
+        @fact log(cl).values[1]  --> log(cl.values[1])
+        @fact sqrt(cl).values[1]  --> sqrt(cl.values[1])
         @fact (+ohlc).values[1,:]  --> ohlc.values[1,:]
         @fact (-ohlc).values[1,:]  --> -(ohlc.values[1,:])
         @fact (!(ohlc .== ohlc)).values[1,1]  --> false
+        @fact log(ohlc).values[1, :]  --> log(ohlc.values[1, :])
+        @fact sqrt(ohlc).values[1, :]  --> sqrt(ohlc.values[1, :])
+        @fact_throws sqrt(-ohlc)
     end
 
     context("correct dot operation between TimeArray values and Int/Float and viceversa") do


### PR DESCRIPTION
Unary operator definitions are essentially identical to calling `basecall` with a particular function, so predefine common scalar->scalar math functions as unary operators for convenience.

Example:

```julia
julia> sqrt(ohlc)
500x4 TimeSeries.TimeArray{Float64,2,Void} 2000-01-03 to 2001-12-31

             sqrtOpen  sqrtHigh  sqrtLow  sqrtClose  
2000-01-03 | 10.2411   10.6066   10.0841  10.5802    
2000-01-04 | 10.4043   10.5176   10.0593  10.1242    
2000-01-05 | 10.1858   10.5148   10.1489  10.198     
2000-01-06 | 10.3015   10.3441   9.7468   9.7468     
⋮
2001-12-26 | 4.6206    4.7223    4.5978   4.6357     
2001-12-27 | 4.6454    4.717     4.6454   4.6979     
2001-12-28 | 4.6872    4.7958    4.6861   4.736      
2001-12-31 | 4.7445    4.7603    4.6723   4.6797     
```