### PR TITLE
show NaN sentinels as NA

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -101,6 +101,8 @@ function show{T,N}(io::IO, ta::TimeArray{T,N})
             print(io, rpad(ta.values[i,j], colwidth[j] + 2, " ")) :
             intcatcher[j] & SHOWINT ?
             print(io, rpad(round(Integer, ta.values[i,j]), colwidth[j] + 2, " ")) : 
+            isnan(ta.values[i,j]) ?
+            print(io, rpad("NA", colwidth[j] + 2, " ")) :
             print(io, rpad(round(ta.values[i,j], DECIMALS), colwidth[j] + 2, " "))
         end
         println(io, "")
@@ -115,6 +117,8 @@ function show{T,N}(io::IO, ta::TimeArray{T,N})
             print(io, rpad(ta.values[i,j], colwidth[j] + 2, " ")) :
             intcatcher[j] & SHOWINT ?
             print(io, rpad(round(Integer, ta.values[i,j]), colwidth[j] + 2, " ")) : 
+            isnan(ta.values[i,j]) ?
+            print(io, rpad("NA", colwidth[j] + 2, " ")) :
             print(io, rpad(round(ta.values[i,j], DECIMALS), colwidth[j] + 2, " "))
         end
         println(io, "")
@@ -127,6 +131,8 @@ function show{T,N}(io::IO, ta::TimeArray{T,N})
             print(io, rpad(ta.values[i,j], colwidth[j] + 2, " ")) :
             intcatcher[j] & SHOWINT ?
             print(io, rpad(round(Integer, ta.values[i,j]), colwidth[j] + 2, " ")) :
+            isnan(ta.values[i,j]) ?
+            print(io, rpad("NA", colwidth[j] + 2, " ")) :
             print(io, rpad(round(ta.values[i,j], DECIMALS), colwidth[j] + 2, " "))
         end
         println(io, "")


### PR DESCRIPTION
I'm tempted to further define missing values as `CBC` (consumed by calculation), `M` (missing), `S` (shifted) and so forth. 

This looks better in my opinion 

````julia
julia> using MarketData, TimeSeries

julia> lag(cl, padding=true)
500x1 TimeSeries.TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31

             Close     
2000-01-03 | NA        
2000-01-04 | 111.94    
2000-01-05 | 102.5     
2000-01-06 | 104.0     
⋮
2001-12-26 | 21.36     
2001-12-27 | 21.49     
2001-12-28 | 22.07     
2001-12-31 | 22.43     
````