### PR TITLE
Multi-column collapse

### DIFF
--- a/docs/source/combine.rst
+++ b/docs/source/combine.rst
@@ -61,8 +61,7 @@ collapse
 The ``collapse`` method allows for compressing data into a larger time frame. For example, converting daily data into monthly data.
 When compressing dates, something rational has to be done with the values that lived in the more granular time frame. To define what
 happens, a function call is made. In our example, we want to compress the daily ``cl`` closing prices from daily to monthly. It makes
-sense for us to take the last value known and have that represented with the derived timestamp. The ``collapse`` keyword argument for
-time frame is the ``week`` method, which is defined in ``Base.Dates``. A list of valid time methods is presented below.
+sense for us to take the ``last`` value known and have that represented with the corresponding timestamp. A non-exhaustive list of valid time methods is presented below.
 
 +--------------+-------------+
 | Dates method | Time length |
@@ -78,7 +77,7 @@ time frame is the ``week`` method, which is defined in ``Base.Dates``. A list of
 
 Showing this code in REPL::
 
-    julia> collapse(cl,last,period=month)
+    julia> collapse(cl,month,last)
     24x1 TimeSeries.TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-31 to 2001-12-31
 
                  Close
@@ -91,6 +90,23 @@ Showing this code in REPL::
     2001-10-31 | 17.56
     2001-11-30 | 21.3
     2001-12-31 | 21.9
+
+We can also supply the function that chooses the timestamp and the function that determines the corresponding value independently::
+
+    julia> collapse(cl, month, last, mean)
+    24x1 TimeSeries.TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-31 to 2001-12-31
+
+		Close     
+    2000-01-31 | 103.3595  
+    2000-02-29 | 111.6375  
+    2000-03-31 | 128.5026  
+    2000-04-28 | 123.1058  
+    ⋮
+    2001-09-28 | 16.602    
+    2001-10-31 | 17.3222   
+    2001-11-30 | 19.649    
+    2001-12-31 | 21.695    
+
 
 vcat
 ----

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -44,7 +44,7 @@ end
 
 # collapse ######################
 
-function collapse{T,N,D}(ta::TimeArray{T,N,D}, value::Function; period::Function=week, timestamp::Function=last)
+function collapse{T,N,D}(ta::TimeArray{T,N,D}, period::Function=week, timestamp::Function=last, value::Function=timestamp)
 
     length(ta) == 0 && return ta
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -63,7 +63,7 @@ function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=wee
 
         if mapped_tstamp != next_mapped_tstamp
           push!(collapsed_tstamps, tstamp)
-          collapsed_values = [collapsed_values; [f(ta.values[cluster_startrow:i, j]) for j in 1:ncols]']
+          collapsed_values = [collapsed_values; T[f(ta.values[cluster_startrow:i, j]) for j in 1:ncols]']
           cluster_startrow = i+1
         end #if
 
@@ -73,7 +73,7 @@ function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=wee
     end #for
 
     push!(collapsed_tstamps, tstamp)
-    collapsed_values = [collapsed_values; [f(ta.values[cluster_startrow:end, j]) for j in 1:ncols]']
+    collapsed_values = [collapsed_values; T[f(ta.values[cluster_startrow:end, j]) for j in 1:ncols]']
 
     N == 1 && (collapsed_values = vec(collapsed_values))
     return TimeArray(collapsed_tstamps, collapsed_values, ta.colnames, ta.meta)

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -44,7 +44,7 @@ end
 
 # collapse ######################
 
-function collapse{T,N,D}(ta::TimeArray{T,N,D}, period::Function=week, timestamp::Function=last, value::Function=timestamp)
+function collapse{T,N,D}(ta::TimeArray{T,N,D}, period::Function, timestamp::Function, value::Function=timestamp)
 
     length(ta) == 0 && return ta
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -44,7 +44,7 @@ end
 
 # collapse ######################
 
-function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=week)
+function collapse{T,N,D}(ta::TimeArray{T,N,D}, collapse_valuecluster::Function; period::Function=week, collapse_timestampcluster::Function=last)
 
     length(ta) == 0 && return ta
 
@@ -62,8 +62,8 @@ function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=wee
         next_mapped_tstamp = period(next_tstamp)
 
         if mapped_tstamp != next_mapped_tstamp
-          push!(collapsed_tstamps, tstamp)
-          collapsed_values = [collapsed_values; T[f(ta.values[cluster_startrow:i, j]) for j in 1:ncols]']
+          push!(collapsed_tstamps, collapse_timestampcluster(ta.timestamp[cluster_startrow:i]))
+          collapsed_values = [collapsed_values; T[collapse_valuecluster(ta.values[cluster_startrow:i, j]) for j in 1:ncols]']
           cluster_startrow = i+1
         end #if
 
@@ -72,8 +72,8 @@ function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=wee
 
     end #for
 
-    push!(collapsed_tstamps, tstamp)
-    collapsed_values = [collapsed_values; T[f(ta.values[cluster_startrow:end, j]) for j in 1:ncols]']
+    push!(collapsed_tstamps, collapse_timestampcluster(ta.timestamp[cluster_startrow:end]))
+    collapsed_values = [collapsed_values; T[collapse_valuecluster(ta.values[cluster_startrow:end, j]) for j in 1:ncols]']
 
     N == 1 && (collapsed_values = vec(collapsed_values))
     return TimeArray(collapsed_tstamps, collapsed_values, ta.colnames, ta.meta)

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -44,7 +44,7 @@ end
 
 # collapse ######################
 
-function collapse{T,N,D}(ta::TimeArray{T,N,D}, collapse_valuecluster::Function; period::Function=week, collapse_timestampcluster::Function=last)
+function collapse{T,N,D}(ta::TimeArray{T,N,D}, value::Function; period::Function=week, timestamp::Function=last)
 
     length(ta) == 0 && return ta
 
@@ -62,8 +62,8 @@ function collapse{T,N,D}(ta::TimeArray{T,N,D}, collapse_valuecluster::Function; 
         next_mapped_tstamp = period(next_tstamp)
 
         if mapped_tstamp != next_mapped_tstamp
-          push!(collapsed_tstamps, collapse_timestampcluster(ta.timestamp[cluster_startrow:i]))
-          collapsed_values = [collapsed_values; T[collapse_valuecluster(ta.values[cluster_startrow:i, j]) for j in 1:ncols]']
+          push!(collapsed_tstamps, timestamp(ta.timestamp[cluster_startrow:i]))
+          collapsed_values = [collapsed_values; T[value(ta.values[cluster_startrow:i, j]) for j in 1:ncols]']
           cluster_startrow = i+1
         end #if
 
@@ -72,8 +72,8 @@ function collapse{T,N,D}(ta::TimeArray{T,N,D}, collapse_valuecluster::Function; 
 
     end #for
 
-    push!(collapsed_tstamps, collapse_timestampcluster(ta.timestamp[cluster_startrow:end]))
-    collapsed_values = [collapsed_values; T[collapse_valuecluster(ta.values[cluster_startrow:end, j]) for j in 1:ncols]']
+    push!(collapsed_tstamps, timestamp(ta.timestamp[cluster_startrow:end]))
+    collapsed_values = [collapsed_values; T[value(ta.values[cluster_startrow:end, j]) for j in 1:ncols]']
 
     N == 1 && (collapsed_values = vec(collapsed_values))
     return TimeArray(collapsed_tstamps, collapsed_values, ta.colnames, ta.meta)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -46,3 +46,44 @@ function findall(ta::TimeArray)
     warn("findall is deprecated, use find instead")
     return find(ta)
 end #findall
+
+function collapse{T,N,D}(ta::TimeArray{T,N,D}, f::Function; period::Function=week)
+
+    warn("collapse(ta::TimeArray, f::Function; period::Function=week) is deprecated,\nuse collapse(ta::TimeArray, period::Function, timestamp::Function, value::Function=timestamp) instead")
+    w = [period(ta.timestamp[t]) for t in 1:length(ta)] # get weekly id from entire array
+    z = Int[]; j = 1
+    for i=1:length(ta) - 1 # create unique period ID array
+        if w[i] != w[i+1]
+            push!(z, j)
+            j = j+1
+        else
+            push!(z,j)
+        end
+    end
+
+    # account for last row
+    w[length(ta)]  ==  w[length(ta)-1] ? # is the last row the same period as 2nd to last row?
+    push!(z, z[length(z)]) :
+    push!(z, z[length(z)] + 1)
+
+    # pre-allocate timestamp and value arrays
+    tstamps = Array{D}(maximum(z))
+    vals    = zeros(maximum(z)) # number of unique periods
+    #replace their values except for the last row
+    for i = 1:maximum(z)-1  # iterate over period ID groupings
+        temp       = ta[findfirst(z .== i):findfirst(z .== i+1)-1] # period's worth that will be squished
+        tstamps[i] = temp[length(temp)].timestamp[1]
+        vals[i]    = f(temp.values)
+    end
+    # and once again account for the last temp that isn't looped on above
+    lasttemp = ta[findfirst(z .== maximum(z)):length(ta)]
+    lasttempindex = lasttemp[length(lasttemp)].timestamp
+    lasttempvalue = f(ta.values)
+
+    # complete the tstamp and vals arrays with the last value
+    tstamps[length(tstamps)] = lasttempindex[1]
+    vals[length(vals)]       = lasttempvalue
+
+    TimeArray(tstamps, vals, ta.colnames, ta.meta)
+end
+

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -5,27 +5,27 @@ FactCheck.onlystats(true)
 facts("collapse operations") do
 
     context("collapse squishes correctly") do
-        @fact collapse(ohlc[1:0], last).values              --> ohlc[1:0].values
+        @fact collapse(ohlc[1:0]).values       --> ohlc[1:0].values
 
-        @fact collapse(cl, last).values[1]                  --> 99.50
-        @fact collapse(cl, last).timestamp[1]               --> Date(2000,1,7)
-        @fact collapse(cl, last, period=month).values[1]    --> 103.75
-        @fact collapse(cl, last, period=month).timestamp[1] --> Date(2000,1,31)
+        @fact collapse(cl).values[1]           --> 99.50
+        @fact collapse(cl).timestamp[1]        --> Date(2000,1,7)
+        @fact collapse(cl, month).values[1]    --> 103.75
+        @fact collapse(cl, month).timestamp[1] --> Date(2000,1,31)
 
-        @fact collapse(ohlc, last).values[1, :]               --> [96.5 101.0 95.5 99.50]
-        @fact collapse(ohlc, last).timestamp[1]               --> Date(2000,1,7)
-        @fact collapse(ohlc, last, period=month).values[1, :] --> [101.0 103.88 94.5 103.75]
-        @fact collapse(ohlc, last, period=month).timestamp[1] --> Date(2000,1,31)
+        @fact collapse(ohlc).values[1, :]        --> [96.5 101.0 95.5 99.50]
+        @fact collapse(ohlc).timestamp[1]        --> Date(2000,1,7)
+        @fact collapse(ohlc, month).values[1, :] --> [101.0 103.88 94.5 103.75]
+        @fact collapse(ohlc, month).timestamp[1] --> Date(2000,1,31)
 
-        @fact collapse(cl, first, timestamp=first).values[2]                  --> 97.75
-        @fact collapse(cl, first, timestamp=first).timestamp[2]               --> Date(2000,1,10)
-        @fact collapse(cl, first, period=month, timestamp=first).values[2]    --> 100.25
-        @fact collapse(cl, first, period=month, timestamp=first).timestamp[2] --> Date(2000,2,1)
+        @fact collapse(cl, week, first).values[2]     --> 97.75
+        @fact collapse(cl, week, first).timestamp[2]  --> Date(2000,1,10)
+        @fact collapse(cl, month, first).values[2]    --> 100.25
+        @fact collapse(cl, month, first).timestamp[2] --> Date(2000,2,1)
 
-        @fact collapse(ohlc, first, timestamp=first).values[2, :]               --> [102.0 102.25 94.75 97.75]
-        @fact collapse(ohlc, first, timestamp=first).timestamp[2]               --> Date(2000,1,10)
-        @fact collapse(ohlc, first, period=month, timestamp=first).values[2, :] --> [104.0 105.0 100.0 100.25]
-        @fact collapse(ohlc, first, period=month, timestamp=first).timestamp[2] --> Date(2000,2,1)
+        @fact collapse(ohlc, week, first).values[2, :]  --> [102.0 102.25 94.75 97.75]
+        @fact collapse(ohlc, week, first).timestamp[2]  --> Date(2000,1,10)
+        @fact collapse(ohlc, month, first).values[2, :] --> [104.0 105.0 100.0 100.25]
+        @fact collapse(ohlc, month, first).timestamp[2] --> Date(2000,2,1)
     end
 end
 

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -17,15 +17,15 @@ facts("collapse operations") do
         @fact collapse(ohlc, last, period=month).values[1, :] --> [101.0 103.88 94.5 103.75]
         @fact collapse(ohlc, last, period=month).timestamp[1] --> Date(2000,1,31)
 
-        @fact collapse(cl, first, collapse_timestampcluster=first).values[2]                  --> 97.75
-        @fact collapse(cl, first, collapse_timestampcluster=first).timestamp[2]               --> Date(2000,1,10)
-        @fact collapse(cl, first, period=month, collapse_timestampcluster=first).values[2]    --> 100.25
-        @fact collapse(cl, first, period=month, collapse_timestampcluster=first).timestamp[2] --> Date(2000,2,1)
+        @fact collapse(cl, first, timestamp=first).values[2]                  --> 97.75
+        @fact collapse(cl, first, timestamp=first).timestamp[2]               --> Date(2000,1,10)
+        @fact collapse(cl, first, period=month, timestamp=first).values[2]    --> 100.25
+        @fact collapse(cl, first, period=month, timestamp=first).timestamp[2] --> Date(2000,2,1)
 
-        @fact collapse(ohlc, first, collapse_timestampcluster=first).values[2, :]               --> [102.0 102.25 94.75 97.75]
-        @fact collapse(ohlc, first, collapse_timestampcluster=first).timestamp[2]               --> Date(2000,1,10)
-        @fact collapse(ohlc, first, period=month, collapse_timestampcluster=first).values[2, :] --> [104.0 105.0 100.0 100.25]
-        @fact collapse(ohlc, first, period=month, collapse_timestampcluster=first).timestamp[2] --> Date(2000,2,1)
+        @fact collapse(ohlc, first, timestamp=first).values[2, :]               --> [102.0 102.25 94.75 97.75]
+        @fact collapse(ohlc, first, timestamp=first).timestamp[2]               --> Date(2000,1,10)
+        @fact collapse(ohlc, first, period=month, timestamp=first).values[2, :] --> [104.0 105.0 100.0 100.25]
+        @fact collapse(ohlc, first, period=month, timestamp=first).timestamp[2] --> Date(2000,2,1)
     end
 end
 

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -16,6 +16,16 @@ facts("collapse operations") do
         @fact collapse(ohlc, last).timestamp[1]               --> Date(2000,1,7)
         @fact collapse(ohlc, last, period=month).values[1, :] --> [101.0 103.88 94.5 103.75]
         @fact collapse(ohlc, last, period=month).timestamp[1] --> Date(2000,1,31)
+
+        @fact collapse(cl, first, collapse_timestampcluster=first).values[2]                  --> 97.75
+        @fact collapse(cl, first, collapse_timestampcluster=first).timestamp[2]               --> Date(2000,1,10)
+        @fact collapse(cl, first, period=month, collapse_timestampcluster=first).values[2]    --> 100.25
+        @fact collapse(cl, first, period=month, collapse_timestampcluster=first).timestamp[2] --> Date(2000,2,1)
+
+        @fact collapse(ohlc, first, collapse_timestampcluster=first).values[2, :]               --> [102.0 102.25 94.75 97.75]
+        @fact collapse(ohlc, first, collapse_timestampcluster=first).timestamp[2]               --> Date(2000,1,10)
+        @fact collapse(ohlc, first, period=month, collapse_timestampcluster=first).values[2, :] --> [104.0 105.0 100.0 100.25]
+        @fact collapse(ohlc, first, period=month, collapse_timestampcluster=first).timestamp[2] --> Date(2000,2,1)
     end
 end
 

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -5,27 +5,22 @@ FactCheck.onlystats(true)
 facts("collapse operations") do
 
     context("collapse squishes correctly") do
-        @fact collapse(ohlc[1:0]).values       --> ohlc[1:0].values
-
-        @fact collapse(cl).values[1]           --> 99.50
-        @fact collapse(cl).timestamp[1]        --> Date(2000,1,7)
-        @fact collapse(cl, month).values[1]    --> 103.75
-        @fact collapse(cl, month).timestamp[1] --> Date(2000,1,31)
-
-        @fact collapse(ohlc).values[1, :]        --> [96.5 101.0 95.5 99.50]
-        @fact collapse(ohlc).timestamp[1]        --> Date(2000,1,7)
-        @fact collapse(ohlc, month).values[1, :] --> [101.0 103.88 94.5 103.75]
-        @fact collapse(ohlc, month).timestamp[1] --> Date(2000,1,31)
 
         @fact collapse(cl, week, first).values[2]     --> 97.75
         @fact collapse(cl, week, first).timestamp[2]  --> Date(2000,1,10)
+        @fact collapse(cl, week, first, last).values[2]     --> 100.44
+        @fact collapse(cl, week, first, last).timestamp[2]  --> Date(2000,1,10)
         @fact collapse(cl, month, first).values[2]    --> 100.25
         @fact collapse(cl, month, first).timestamp[2] --> Date(2000,2,1)
 
         @fact collapse(ohlc, week, first).values[2, :]  --> [102.0 102.25 94.75 97.75]
         @fact collapse(ohlc, week, first).timestamp[2]  --> Date(2000,1,10)
+        @fact collapse(ohlc, week, first, last).values[2, :]  --> [100.0 102.25 99.38 100.44]
+        @fact collapse(ohlc, week, first, last).timestamp[2]  --> Date(2000,1,10)
         @fact collapse(ohlc, month, first).values[2, :] --> [104.0 105.0 100.0 100.25]
         @fact collapse(ohlc, month, first).timestamp[2] --> Date(2000,2,1)
+
+
     end
 end
 

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -5,10 +5,17 @@ FactCheck.onlystats(true)
 facts("collapse operations") do
 
     context("collapse squishes correctly") do
+        @fact collapse(ohlc[1:0], last).values              --> ohlc[1:0].values
+
         @fact collapse(cl, last).values[1]                  --> 99.50
         @fact collapse(cl, last).timestamp[1]               --> Date(2000,1,7)
         @fact collapse(cl, last, period=month).values[1]    --> 103.75
         @fact collapse(cl, last, period=month).timestamp[1] --> Date(2000,1,31)
+
+        @fact collapse(ohlc, last).values[1, :]               --> [96.5 101.0 95.5 99.50]
+        @fact collapse(ohlc, last).timestamp[1]               --> Date(2000,1,7)
+        @fact collapse(ohlc, last, period=month).values[1, :] --> [101.0 103.88 94.5 103.75]
+        @fact collapse(ohlc, last, period=month).timestamp[1] --> Date(2000,1,31)
     end
 end
 

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -38,4 +38,11 @@ facts("deprecated methods") do
     context("deprecated findall returns correct indices") do
         @fact findall(cl .> op) --> find(cl .> op)
     end
+
+    context("deprecated collapse squishes correctly") do
+        @fact collapse(cl, last).values[1]                  --> 99.50
+        @fact collapse(cl, last).timestamp[1]               --> Date(2000,1,7)
+        @fact collapse(cl, last, period=month).values[1]    --> 103.75
+        @fact collapse(cl, last, period=month).timestamp[1] --> Date(2000,1,31)
+    end
 end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -83,7 +83,7 @@ facts("combine operations preserve meta") do
     end
 
     context("collapse") do
-        @fact collapse(mdata).meta --> "Apple"
+        @fact collapse(mdata, week, first).meta --> "Apple"
     end
 end
 

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -83,7 +83,7 @@ facts("combine operations preserve meta") do
     end
 
     context("collapse") do
-        @fact collapse(mdata, last).meta --> "Apple"
+        @fact collapse(mdata).meta --> "Apple"
     end
 end
 


### PR DESCRIPTION
Fixes #243 to allow `collapse` operations on 2D TimeArrays, with appropriate tests. Scores a nice speedup as well:

`master`:
```julia
julia> using TimeSeries, MarketData

julia> collapse(BA["Open"], last); @time collapse(BA["Open"], last);
  0.188057 seconds (294.44 k allocations: 46.848 MB, 2.21% gc time)
```

this PR:
```julia
julia> using TimeSeries, MarketData

julia> collapse(BA["Open"], last); @time collapse(BA["Open"], last);
  0.026178 seconds (118.08 k allocations: 33.954 MB, 12.61% gc time)
```

While we're looking at this, should there be an option for what timestamp is used to represent the downsampled rows? The current approach is to use the last timestamp in the cluster, although I think using the first timestamp would be just as justifiable (in fact preferable for my typical use cases).

Also, I think ideally the collapsed timestamps would represent the beginning/end of the specified time period, not just the first/last timestamp observed in said period - for example if I'm collapsing data down to a monthly average but my first observation in January is 11pm on the 3rd, I'd rather have the average associated with `2016-01-01T00:00:00` as opposed to `2016-01-03T23:00:00`. Implementing this would be more involved though, and would probably be hard to keep generalized for arbitrary `TimeType` timestamps...