### PR TITLE
Support element-wise math across heterogeneous Number subtypes - fix #224

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### 0.7.4 (unreleased)
+
+* allow math operations between different Number subtypes
+
 ### 0.7.3
 
 * ensure dates are sorted for vcat and map (@dourouc05)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
+### 0.7.3
+
+* ensure dates are sorted for vcat and map (@dourouc05)
+
 ### 0.7.2
 
-* map and vcat methods added (thanks again dourouc05)
+* map and vcat methods added (thanks again @dourouc05)
 
 ### 0.7.1
 
-* readtimearray method now allows arbitrary delimiters (thanks dourouc05) 
+* readtimearray method now allows arbitrary delimiters (thanks @dourouc05) 
 
 ### 0.7.0
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -14,6 +14,6 @@ Throughout this tutorial, we'll be using historical financial data sets, which a
 To create dummy data without using the ``MarketData`` package, simply use the following code block::
 
     dates  = [Date(1999,1,1):Date(2000,12,31)]
-    mytime = TimeArray(dates, rand(length(dates), ["test"])
+    mytime = TimeArray(dates, rand(length(dates)), ["test"])
 
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -56,7 +56,7 @@ end # loop
 # ND TimeArray <--> MD TimeArray
 for op in [MATH_DOTONLY; COMPARE_DOTONLY]
     @eval begin
-        function ($op){T<:Number,N,M}(ta1::TimeArray{T,N}, ta2::TimeArray{T,M})
+        function ($op){S<:Number,T<:Number,N,M}(ta1::TimeArray{S,N}, ta2::TimeArray{T,M})
             # first test metadata matches
             ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
             # determine array widths and name cols accordingly

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -188,12 +188,16 @@ facts("base element-wise operators on TimeArray values") do
         @fact (cl ./ op).values[1]      --> roughly(1.067315, atol=0.001)
         @fact (cl .% op).values         --> cl.values .% op.values
         @fact (cl .^ op).values         --> cl.values .^ op.values
+        @fact (cl .* (cl.> 200)).values --> cl.values .* (cl.values .> 200)
+        @fact (basecall(cl, x->round(Int, x)) .* cl).values --> round(Int, cl.values) .* cl.values
         @fact (ohlc .+ ohlc).values     --> ohlc.values .+ ohlc.values
         @fact (ohlc .- ohlc).values     --> ohlc.values .- ohlc.values
         @fact (ohlc .* ohlc).values     --> ohlc.values .* ohlc.values
         @fact (ohlc ./ ohlc).values     --> ohlc.values ./ ohlc.values
         @fact (ohlc .% ohlc).values     --> ohlc.values .% ohlc.values
         @fact (ohlc .^ ohlc).values     --> ohlc.values .^ ohlc.values
+        @fact (ohlc .* (ohlc .> 200)).values --> ohlc.values .* (ohlc.values .> 200)
+        @fact (basecall(ohlc, x->round(Int, x)) .* ohlc).values --> round(Int, ohlc.values) .* ohlc.values
     end
 
     context("correct broadcasted mathematical operations between different-column-count TimeArrays") do
@@ -203,12 +207,16 @@ facts("base element-wise operators on TimeArray values") do
         @fact (ohlc ./ cl).values --> ohlc.values ./ cl.values
         @fact (ohlc .% cl).values --> ohlc.values .% cl.values
         @fact (ohlc .^ cl).values --> ohlc.values .^ cl.values
+        @fact (ohlc .* (cl.> 200)).values --> ohlc.values .* (cl.values .> 200)
+        @fact (basecall(ohlc, x->round(Int, x)) .* cl).values --> round(Int, ohlc.values) .* cl.values
         @fact (cl .+ ohlc).values --> cl.values .+ ohlc.values
         @fact (cl .- ohlc).values --> cl.values .- ohlc.values
         @fact (cl .* ohlc).values --> cl.values .* ohlc.values
         @fact (cl ./ ohlc).values --> cl.values ./ ohlc.values
         @fact (cl .% ohlc).values --> cl.values .% ohlc.values
         @fact (cl .^ ohlc).values --> cl.values .^ ohlc.values
+        @fact (cl .* (ohlc .> 200)).values --> cl.values .* (ohlc.values .> 200)
+        @fact (basecall(cl, x->round(Int, x)) .* ohlc).values --> round(Int, cl.values) .* ohlc.values
         @fact_throws (ohlc["Open", "Close"] .+ ohlc) # One array must have a single column
     end
 


### PR DESCRIPTION
Before:

```julia
julia> using MarketData

julia> cl .* (cl .> 100)
ERROR: MethodError: `.*` has no method matching .*(::TimeSeries.TimeArray{Float64,1,Date,Array{Float64,1}}, ::TimeSeries.TimeArray{Bool,1,Date,BitArray{1}})
Closest candidates are:
  .*{T<:Number,N}(::TimeSeries.TimeArray{T<:Number,N,D<:Base.Dates.TimeType,A<:AbstractArray{T,N}}, ::Number)
  .*{T<:Number,N}(::Number, ::TimeSeries.TimeArray{T<:Number,N,D<:Base.Dates.TimeType,A<:AbstractArray{T,N}})
  .*{T<:Number,N,M}(::TimeSeries.TimeArray{T<:Number,N,D<:Base.Dates.TimeType,A<:AbstractArray{T,N}}, ::TimeSeries.TimeArray{T<:Number,M,D<:Base.Dates.TimeType,A<:AbstractArray{T,N}})
```

After:

```julia
julia> using MarketData

julia> cl .* (cl .> 100)
500x1 TimeSeries.TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31

             Close.*Close.>100  
2000-01-03 | 111.94             
2000-01-04 | 102.5              
2000-01-05 | 104.0              
2000-01-06 | 0.0                
⋮
2001-12-26 | 0.0                
2001-12-27 | 0.0                
2001-12-28 | 0.0                
2001-12-31 | 0.0
```
