### PR TITLE
WIP: Removed Vector{D<:TimeType} constraint on timestamp construction

### DIFF
--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -8,7 +8,18 @@ facts("field extraction methods work") do
         @fact typeof(timestamp(cl)) --> Array{Date,1}
         @fact typeof(values(cl))    --> Array{Float64,1}
         @fact typeof(colnames(cl))  --> Array{UTF8String,1}
-        @fact meta(mdata)           --> "Apple" 
+        @fact meta(mdata)           --> "Apple"
+    end
+end
+
+facts("Alternative collections and eltypes work") do
+    context("Correct alternative collection types") do
+        @fact typeof(timestamp(TimeArray(range(now(),Second(1),5),0:4,[""]))) --> StepRange{DateTime,Second}
+        @fact typeof(values(TimeArray(range(now(),Second(1),5),0:4,[""]))) --> UnitRange{Int64}
+    end
+    context("Correct Number based ad-hoc time eltypes") do
+        @fact typeof(timestamp(TimeArray(1:5,0:4,[""]))) --> UnitRange{Int64}
+        @fact typeof(timestamp(TimeArray([.1,.2,.6,.7,.9],0:4,[""]))) --> Array{Float64,1}
     end
 end
 
@@ -17,25 +28,25 @@ facts("type constructors enforce invariants") do
     context("unequal length between values and timestamp fails") do
         @fact_throws TimeArray(cl.timestamp, cl.values[2:end], ["Close"])
     end
-  
+
     context("unequal length between colnames and array width fails") do
         @fact_throws TimeArray(cl.timestamp, cl.values, ["Close", "Open"])
     end
-  
+
     context("duplicate timestamp values fails") do
         @fact_throws TimeArray(dupestamp, push!(cl.values, cl.values[1]), ["Close"])
     end
-  
+
     context("mangled order of timestamp values fails") do
         @fact_throws TimeArray(mangstamp,  push!(cl.values, cl.values[1]), ["Close"])
     end
-  
+
     context("flipping occurs when needed") do
         @fact TimeArray(flipdim(cl.timestamp, 1), flipdim(cl.values, 1),  ["Close"]).timestamp[1] --> Date(2000,1,3)
         @fact TimeArray(flipdim(cl.timestamp, 1), flipdim(cl.values, 1),  ["Close"]).values[1]    --> 111.94
     end
 end
-  
+
 facts("conversion methods") do
 
     context("convert works ") do
@@ -64,38 +75,38 @@ facts("ordered collection methods") do
         @fact ohlc[1].timestamp              --> [Date(2000,1,3)]
         @fact ohlc[Date(2000,1,3)].timestamp --> [Date(2000,1,3)]
     end
-    
+
     context("getindex on array of Int and Date") do
         @fact ohlc[[1,10]].timestamp                           --> [Date(2000,1,3), Date(2000,1,14)]
         @fact ohlc[[Date(2000,1,3),Date(2000,1,14)]].timestamp --> [Date(2000,1,3), Date(2000,1,14)]
     end
-  
+
     context("getindex on range of Int and Date") do
         @fact ohlc[1:2].timestamp                                  --> [Date(2000,1,3), Date(2000,1,4)]
         @fact ohlc[Date(2000,1,3):Day(1):Date(2000,1,4)].timestamp --> [Date(2000,1,3), Date(2000,1,4)]
     end
-  
+
     context("getindex on range of DateTime when only Date is in timestamp") do
         @fact_throws ohlc[DateTime(2000,1,3,0,0,0)]
         @fact_throws ohlc[[DateTime(2000,1,3,0,0,0),DateTime(2000,1,14,0,0,0)]]
         @fact_throws ohlc[DateTime(2000,1,3,0,0,0):Day(1):DateTime(2000,1,4,0,0,0)]
     end
-  
+
     context("getindex on range of Date") do
         @fact length(cl[Date(2000,1,1):Date(2001,12,31)]) --> 500
     end
-  
+
     context("getindex on single column name") do
         @fact size(ohlc["Open"].values, 2)                                        --> 1
         @fact size(ohlc["Open"][Date(2000,1,3):Day(1):Date(2000,1,14)].values, 1) --> 10
     end
-  
+
     context("getindex on multiple column name") do
         @fact ohlc["Open", "Close"].values[1]   --> 104.88
         @fact ohlc["Open", "Close"].values[2]   --> 108.25
         @fact ohlc["Open", "Close"].values[501] --> 111.94
     end
-  
+
     context("getindex on 1d returns 1d object") do
         @fact isa(cl[1], TimeArray{Float64,1})   --> true
         @fact isa(cl[1:2], TimeArray{Float64,1}) --> true
@@ -116,4 +127,3 @@ facts("show methods don't throw errors") do
     show(ohlc[1:0])
 
 end
-


### PR DESCRIPTION
This is a proof of concept for a set of features to solve #250. The main work so far is to remove the constrain that timestamps be `Vector{D<:TimeType}`. Examples of new functionality can be found in the test. On this note, I have to confess that this is my first time seeing Midje-like testing, so I am not so sure about the logical organization of these tests. Any suggestions would be appreciated

On a more substantial note, the current implementation of this behavior adds one more type parameter to `TimeArray` to encode the timestamp container type. So it start to look like a bunch of parameters. However, in my first pass through the source, I didn't see anywhere were it would be strictly needed to have the time eltype available to a method, as this could be read from the timestamp container. So it might be possible to remove the D parameter from the type.