### PR TITLE
Allow operations on TimeArrays with non-matching meta - address #249

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * allow math operations between different Number subtypes
 * explicitly convert column names to strings  in `readtimearray`
+* operations between TimeArrays with non-matching meta fields now succeed, with a `Void` meta in the result
 
 ### 0.7.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### 0.7.4 (unreleased)
 
 * allow math operations between different Number subtypes
+* explicitly convert column names to strings  in `readtimearray`
 
 ### 0.7.3
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -57,8 +57,10 @@ end # loop
 for op in [MATH_DOTONLY; COMPARE_DOTONLY]
     @eval begin
         function ($op){S<:Number,T<:Number,N,M}(ta1::TimeArray{S,N}, ta2::TimeArray{T,M})
+
             # first test metadata matches
-            ta1.meta == ta2.meta ? meta = ta1.meta : error("metadata doesn't match")
+            meta = ta1.meta == ta2.meta ? ta1.meta : Void
+
             # determine array widths and name cols accordingly
             w1, w2  = length(ta1.colnames), length(ta2.colnames)
             if w1 == w2
@@ -70,14 +72,18 @@ for op in [MATH_DOTONLY; COMPARE_DOTONLY]
             else
               error("arrays must have the same number of columns, or one must be a single column")
             end
+
             # obtain shared timestamp
             idx1, idx2 = overlaps(ta1.timestamp, ta2.timestamp)
             tstamp = ta1[idx1].timestamp
+
             # retrieve values that match the Int array matching dates
             vals1, vals2 = ta1[idx1].values, ta2[idx2].values
+
             # compute output values
             vals = ($op)(vals1, vals2)
             TimeArray(tstamp, vals, cnames, meta)
+
         end # function
     end # eval
 end # loop

--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -22,7 +22,7 @@ function readtimearray(fname::AbstractString; delim::Char=',', meta=nothing, for
     vals   = insertNaN(cfile[2:end, 2:end])
     cnames = UTF8String[]
     for c in cfile[1, 2:end]
-        push!(cnames, c)
+        push!(cnames, string(c))
     end
     TimeArray(tstamps, vals, cnames, meta)
 end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -76,10 +76,27 @@ facts("combine operations preserve meta") do
 
     context("merge when both have identical meta") do
         @fact merge(mdata, mdata).meta --> "Apple"
+        @fact merge(mdata, mdata, :left).meta --> "Apple"
+        @fact merge(mdata, mdata, :right).meta --> "Apple"
+        @fact merge(mdata, mdata, :outer).meta --> "Apple"
     end
 
     context("merge when both have different meta") do
-        @fact_throws merge(mdata,cl).meta 
+        @fact merge(mdata, cl).meta --> Void
+        @fact merge(mdata, cl, :left).meta --> Void
+        @fact merge(mdata, cl, :right).meta --> Void
+        @fact merge(mdata, cl, :outer).meta --> Void
+    end
+
+    context("merge when supplied with meta") do
+        @fact merge(mdata, mdata, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, mdata, :left, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, mdata, :right, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, mdata, :outer, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, cl, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, cl, :left, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, cl, :right, meta="new meta").meta --> "new meta"
+        @fact merge(mdata, cl, :outer, meta="new meta").meta --> "new meta"
     end
 
     context("collapse") do
@@ -98,10 +115,12 @@ facts("mathematical and comparison operations preserve meta") do
 
     context(".+") do
         @fact (mdata .+ mdata).meta --> "Apple"
+        @fact (mdata .+ cl).meta --> Void
     end
 
     context(".<") do
         @fact (mdata .< mdata).meta --> "Apple"
+        @fact (mdata .< cl).meta --> Void
     end
 end
 


### PR DESCRIPTION
Added default (`Void`) metadata to merge and math operation results when input metas don't match. Also allows for meta to be set explicitly during merge. 