### PR TITLE
Explicitly convert column headings to strings in readtimearray

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### 0.7.4 (unreleased)
 
 * allow math operations between different Number subtypes
+* explicitly convert column names to strings  in `readtimearray`
 
 ### 0.7.3
 

--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -22,7 +22,7 @@ function readtimearray(fname::AbstractString; delim::Char=',', meta=nothing, for
     vals   = insertNaN(cfile[2:end, 2:end])
     cnames = UTF8String[]
     for c in cfile[1, 2:end]
-        push!(cnames, c)
+        push!(cnames, string(c))
     end
     TimeArray(tstamps, vals, cnames, meta)
 end


### PR DESCRIPTION
Fixes an issue where column headings might not be automatically interpreted as strings during file loading (for example, if column names are numbers).