### PR TITLE
Don't do using Dates outside the top package module

### DIFF
--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -1,7 +1,5 @@
 VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 
-using Base.Dates
-
 module TimeSeries
 
 using Base.Dates


### PR DESCRIPTION
This pulls in the exports outside of the package whenever anyone uses it, rather than just inside the package's module.