### PR TITLE
More robust to() and from()

### DIFF
--- a/src/split.jl
+++ b/src/split.jl
@@ -8,14 +8,16 @@ when{T,N}(ta::TimeArray{T,N}, period::Function, t::ASCIIString) = ta[find(period
 # from, to ######################
  
 from{T,N,D}(ta::TimeArray{T,N,D}, d::D) =
-    d < ta.timestamp[1] ? ta :
-    d > ta.timestamp[end] ? ta[1:0] :
-    ta[searchsortedfirst(ta.timestamp, d):end]
+    length(ta) == 0 ? ta : 
+         d < ta.timestamp[1] ? ta :
+         d > ta.timestamp[end] ? ta[1:0] :
+         ta[searchsortedfirst(ta.timestamp, d):end]
 
 to{T,N,D}(ta::TimeArray{T,N,D}, d::D) =
-    d < ta.timestamp[1] ? ta[1:0] :
-    d > ta.timestamp[end] ? ta :
-    ta[1:searchsortedlast(ta.timestamp, d)]
+    length(ta) == 0 ? ta : 
+        d < ta.timestamp[1] ? ta[1:0] :
+        d > ta.timestamp[end] ? ta :
+        ta[1:searchsortedlast(ta.timestamp, d)]
 
 ###### find ##################
 

--- a/test/split.jl
+++ b/test/split.jl
@@ -17,9 +17,14 @@ end
 
 facts("split date operations") do
 
-    context("from and to correctly subset") do
+    context("from and to correctly subset") do # Including zero-length time series
         @fact length(from(cl, Date(2001,12,28))) --> 2
+        @fact length(from(cl, Date(2002,1,1)))   --> 0
+        @fact length(from(from(cl, Date(2002,1,1)), Date(2012,1,1))) --> 0 
+        
         @fact length(to(cl, Date(2000,1,4)))     --> 2
+        @fact length(to(cl, Date(1999,1,4)))     --> 0 
+        @fact length(to(to(cl, Date(1999,1,4)), Date(1912,1,1))) --> 0 
     end
         
     context("when method correctly subset") do


### PR DESCRIPTION
Useful when the time series is empty (e.g. due to a previous filtering with `to` or `from`).