### PR TITLE
added basic plot recipe

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+RecipesBase

--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -3,6 +3,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 module TimeSeries
 
 using Base.Dates
+using RecipesBase
 
 export TimeArray, AbstractTimeSeries,
        when, from, to, findwhen, find, timestamp, values, colnames, meta, head, tail,
@@ -17,7 +18,7 @@ export TimeArray, AbstractTimeSeries,
 
 include(".timeseriesrc.jl")
 include("timearray.jl")
-include("split.jl") 
+include("split.jl")
 include("apply.jl")
 include("combine.jl")
 include("readwrite.jl")
@@ -25,5 +26,6 @@ include("utilities.jl")
 include("modify.jl")
 include("deprecated.jl")
 include("Base.Dates.jl")
+include("plotrecipes.jl")
 
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,6 +1,6 @@
 
 @recipe function f{T<:TimeArray}(ta::T)
-       labels --> reshape(ta.colnames,1,length(ta.colnames))
-       seriestype --> :path
-       ta.timestamp, ta.values
+    labels --> reshape(ta.colnames,1,length(ta.colnames))
+    seriestype --> :path
+    ta.timestamp, ta.values
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,0 +1,6 @@
+
+@recipe function f{T<:TimeArray}(ta::T)
+       labels --> reshape(ta.colnames,1,length(ta.colnames))
+       seriestype --> :path
+       ta.timestamp, ta.values
+end


### PR DESCRIPTION
This adds basic plotting functionality to TimeArray objects, with a very light dependency (RecipesBase a single macro). It allows plotting as simply as `plot(ohlc)`.
Discussed here https://github.com/JuliaPlots/StatPlots.jl/issues/37#issuecomment-278708392 and here https://github.com/JuliaStats/TimeSeries.jl/issues/302 .

The current recipe will plot all values in the array, which may not make sense if they are not on the same scale, but you can always `plot(ohlcv["Volume"])`.