### PR TITLE
allow views of timestamps in constructors

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -11,7 +11,7 @@ immutable TimeArray{T, N, D<:TimeType, A<:AbstractArray} <: AbstractTimeSeries
     colnames::Vector{String}
     meta::Any
 
-    function TimeArray(timestamp::Vector{D},
+    function TimeArray(timestamp::AbstractVector{D},
                        values::AbstractArray{T,N},
                        colnames::Vector{String},
                        meta::Any)
@@ -29,18 +29,19 @@ immutable TimeArray{T, N, D<:TimeType, A<:AbstractArray} <: AbstractTimeSeries
     end
 end
 
-TimeArray{T,N,D<:TimeType,S<:AbstractString}(d::Vector{D}, v::AbstractArray{T,N}, c::Vector{S}, m::Any) =
+TimeArray{T,N,D<:TimeType,S<:AbstractString}(d::AbstractVector{D}, v::AbstractArray{T,N}, c::Vector{S}, m::Any) =
         TimeArray{T,N,D,typeof(v)}(d,v,map(String,c),m)
 TimeArray{T,N,D<:TimeType,S<:AbstractString}(d::D, v::AbstractArray{T,N}, c::Vector{S}, m::Any) =
         TimeArray{T,N,D,typeof(v)}([d],v,map(String,c),m)
 
 # when no column names are provided - meta is forced to nothing
-TimeArray{T,N,D<:TimeType}(d::Vector{D}, v::AbstractArray{T,N}) = TimeArray(d,v,fill("", size(v,2)),nothing)
+TimeArray{T,N,D<:TimeType}(d::AbstractVector{D}, v::AbstractArray{T,N}) = TimeArray(d,v,fill("", size(v,2)),nothing)
 TimeArray{T,N,D<:TimeType}(d::D, v::AbstractArray{T,N}) = TimeArray([d],v,fill("", size(v,2)),nothing)
 
 # when no meta is provided
-TimeArray{T,N,D<:TimeType}(d::Vector{D}, v::AbstractArray{T,N}, c) = TimeArray(d,v,c,nothing)
+TimeArray{T,N,D<:TimeType}(d::AbstractVector{D}, v::AbstractArray{T,N}, c) = TimeArray(d,v,c,nothing)
 TimeArray{T,N,D<:TimeType}(d::D, v::AbstractArray{T,N}, c) = TimeArray([d],v,c,nothing)
+
 
 ###### conversion ###############
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -56,16 +56,18 @@ facts("type constructors enforce invariants") do
 end
 
 facts("type constructors allow views") do
-    
+
     source_rows = 101:121
-    source_cols = 1:size(AAPL.values)[2]    
-    
-    AAPL1 = TimeArray(AAPL.timestamp[source_rows], AAPL.values[source_rows, source_cols], AAPL.colnames, AAPL.meta)
-    
+    source_cols = 1:size(AAPL.values)[2]
+
+    AAPL1 = TimeArray(AAPL.timestamp[source_rows],
+                      AAPL.values[source_rows, source_cols],
+                      AAPL.colnames, AAPL.meta)
+
     tstamps = view(AAPL.timestamp, source_rows)
     tvalues = view(AAPL.values, source_rows, source_cols)
-    
-    APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
+
+    AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
     @fact length(AAPL1) --> length(AAPL2)
     @fact AAPL1[5].values[3] --> AAPL2[5].values[3]
@@ -76,8 +78,8 @@ facts("type constructors allow views") do
     context("match final values") do
         @fact AAPL[121].values --> AAPL2[end].values)
     end
-=#   
-end    
+=#
+end
 
 facts("construction without colnames") do
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -57,21 +57,23 @@ end
 
 facts("type constructors allow views") do
     
-    items = 101:121
-    ncols = 1:size(AAPL.values)[2]
-    tstamps = view(AAPL.timestamp, items)
-    tvalues = view(AAPL.values, items, ncols)
+    source_rows = 101:121
+    source_cols = 1:size(AAPL.values)[2]    
+    AAPL1 = TimeArray(AAPL.timestamp[source_rows], AAPL.values[source_rows, source_cols], AAPL.colnames, AAPL.meta)
+    tstamps = view(AAPL.timestamp, source_rows)
+    tvalues = view(AAPL.values, source_rows, source_cols)
     APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
-    context("timestamp, values, colnames and meta") do
-        @fact typeof(AAPL[1].timestamp) --> Array{Date,1}
-    end
+    @fact length(AAPL1) --> length(AAPL2)
+    @fact AAPL1[5].values[3] --> AAPL2[5].values[3]
+#=
     context("match first date") do
         @fact AAPL[101].timestamp --> APL2[1].timestamp
     end
     context("match final values") do
         @fact AAPL[121].values --> AAPL2[end].values)
-    end    
+    end
+=#   
 end    
 
 facts("construction without colnames") do

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -70,7 +70,7 @@ facts("type constructors allow views") do
     AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
     context("match first date") do
-        @fact AAPL1[1].timestamp --> APL2[1].timestamp
+        @fact AAPL1[1].timestamp --> AAPL2[1].timestamp
     end
     context("match all values") do
         @fact AAPL1.values --> AAPL2.values

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -12,6 +12,28 @@ facts("field extraction methods work") do
     end
 end
 
+
+facts("type constructors allow views") do
+
+    source_rows = 101:121
+    source_cols = 1:size(AAPL.values)[2]
+    tstamps = view(AAPL.timestamp, source_rows)
+    tvalues = view(AAPL.values, source_rows, source_cols)
+
+    AAPL1 = TimeArray(AAPL.timestamp[source_rows],
+                      AAPL.values[source_rows, source_cols],
+                      AAPL.colnames, AAPL.meta)
+    AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
+
+    context("match first date") do
+        @fact AAPL1[1].timestamp --> AAPL2[1].timestamp
+    end
+    context("match first values") do
+        @fact AAPL1[1].values --> AAPL[1].values
+    end
+end
+
+
 facts("type constructors enforce invariants") do
 
     mangled_stamp = vcat(cl.timestamp[200:end], cl.timestamp[1:199])
@@ -52,28 +74,6 @@ facts("type constructors enforce invariants") do
         @fact dupe_cnames.colnames[10] --> "e_2"
         @fact dupe_cnames.colnames[11] --> "e_3"
         @fact dupe_cnames.colnames[12] --> "f"
-    end
-end
-
-facts("type constructors allow views") do
-
-    source_rows = 101:121
-    source_cols = 1:size(AAPL.values)[2]
-
-    AAPL1 = TimeArray(AAPL.timestamp[source_rows],
-                      AAPL.values[source_rows, source_cols],
-                      AAPL.colnames, AAPL.meta)
-
-    tstamps = view(AAPL.timestamp, source_rows)
-    tvalues = view(AAPL.values, source_rows, source_cols)
-
-    AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
-
-    context("match first date") do
-        @fact AAPL1[1].timestamp --> AAPL2[1].timestamp
-    end
-    context("match all values") do
-        @fact AAPL1.values --> AAPL2.values
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -55,6 +55,16 @@ facts("type constructors enforce invariants") do
     end
 end
 
+facts("type constructors allow views") do    
+    items = 101:121
+    cols = 1:size(AAPL.values)[2]
+    tstamps = view(AAPL.timestamp, items)
+    tvalues = view(AAPL.values, items, cols)
+    APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
+    
+    @test AAPL[101:121] == AAPL2[1:end]
+ nd    
+
 facts("construction without colnames") do
 
     no_colnames_one   = TimeArray(cl.timestamp, cl.values)

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -66,7 +66,7 @@ facts("type constructors allow views") do
     context("match first date") do
         @fact AAPL[101].timestamp - AAPL2[1].timestamp --> Base.Dates.Day(0)
     end
-    context("match all values")
+    context("match all values") do
         @fact all((AAPL[items].values .- AAPL2.values) .== 0.0) --> true
     end    
 end    

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -59,9 +59,12 @@ facts("type constructors allow views") do
     
     source_rows = 101:121
     source_cols = 1:size(AAPL.values)[2]    
+    
     AAPL1 = TimeArray(AAPL.timestamp[source_rows], AAPL.values[source_rows, source_cols], AAPL.colnames, AAPL.meta)
+    
     tstamps = view(AAPL.timestamp, source_rows)
     tvalues = view(AAPL.values, source_rows, source_cols)
+    
     APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
     @fact length(AAPL1) --> length(AAPL2)

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -62,12 +62,15 @@ facts("type constructors allow views") do
     tstamps = view(AAPL.timestamp, items)
     tvalues = view(AAPL.values, items, ncols)
     APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
-    
-    context("match first date") do
-        @fact AAPL[101].timestamp - AAPL2[1].timestamp --> Base.Dates.Day(0)
+
+    context("timestamp, values, colnames and meta") do
+        @fact typeof(AAPL[1].timestamp) --> Array{Date,1}
     end
-    context("match all values") do
-        @fact all((AAPL[items].values .- AAPL2.values) .== 0.0) --> true
+    context("match first date") do
+        @fact AAPL[101].timestamp --> APL2[1].timestamp
+    end
+    context("match final values") do
+        @fact AAPL[121].values --> AAPL2[end].values)
     end    
 end    
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -73,7 +73,7 @@ facts("type constructors allow views") do
         @fact AAPL[101].timestamp --> APL2[1].timestamp
     end
     context("match final values") do
-        @fact AAPL[121].values --> AAPL2[end].values)
+        @fact AAPL[121].values --> AAPL2[end].values
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -30,7 +30,10 @@ facts("type constructors allow views") do
         @fact AAPL1[1].timestamp --> AAPL2[1].timestamp
     end
     context("match first values") do
-        @fact AAPL1[1].values --> AAPL[1].values
+        @fact AAPL1[1].values --> AAPL2[1].values
+    end
+    context("match all values") do
+        @fact AAPL1.values --> AAPL2.values
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -23,6 +23,7 @@ facts("type constructors allow views") do
     AAPL1 = TimeArray(AAPL.timestamp[source_rows],
                       AAPL.values[source_rows, source_cols],
                       AAPL.colnames, AAPL.meta)
+
     AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
     context("match first date") do

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -69,16 +69,12 @@ facts("type constructors allow views") do
 
     AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
-    @fact length(AAPL1) --> length(AAPL2)
-    @fact AAPL1[5].values[3] --> AAPL2[5].values[3]
-#=
     context("match first date") do
         @fact AAPL[101].timestamp --> APL2[1].timestamp
     end
     context("match final values") do
         @fact AAPL[121].values --> AAPL2[end].values)
     end
-=#
 end
 
 facts("construction without colnames") do

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -70,10 +70,10 @@ facts("type constructors allow views") do
     AAPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
 
     context("match first date") do
-        @fact AAPL[101].timestamp --> APL2[1].timestamp
+        @fact AAPL1[1].timestamp --> APL2[1].timestamp
     end
-    context("match final values") do
-        @fact AAPL[121].values --> AAPL2[end].values
+    context("match all values") do
+        @fact AAPL1.values --> AAPL2.values
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -58,14 +58,16 @@ end
 facts("type constructors allow views") do
     
     items = 101:121
-    cols = 1:size(AAPL.values)[2]
+    ncols = 1:size(AAPL.values)[2]
     tstamps = view(AAPL.timestamp, items)
-    tvalues = view(AAPL.values, items, cols)
+    tvalues = view(AAPL.values, items, ncols)
     APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
     
-    context("match dates and values") do
-        @fact AAPL[101].values --> AAPL2[1].values
-        @fact AAPL[101].timestamp --> AAPL2[1].timestamp
+    context("match first date") do
+        @fact AAPL[101].timestamp - AAPL2[1].timestamp --> Base.Dates.Day(0)
+    end
+    context("match all values")
+        @fact all((AAPL[items].values .- AAPL2.values) .== 0.0) --> true
     end    
 end    
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -63,8 +63,10 @@ facts("type constructors allow views") do
     tvalues = view(AAPL.values, items, cols)
     APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
     
-    @fact AAPL[101] --> AAPL2[1]
-    @fact AAPL[121] --> AAPL2[end]
+    context("match dates and values") do
+        @fact AAPL[101].values --> AAPL2[1].values
+        @fact AAPL[101].timestamp --> AAPL2[1].timestamp
+    end    
 end    
 
 facts("construction without colnames") do

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -55,15 +55,17 @@ facts("type constructors enforce invariants") do
     end
 end
 
-facts("type constructors allow views") do    
+facts("type constructors allow views") do
+    
     items = 101:121
     cols = 1:size(AAPL.values)[2]
     tstamps = view(AAPL.timestamp, items)
     tvalues = view(AAPL.values, items, cols)
     APPL2 = TimeArray(tstamps, tvalues, AAPL.colnames, AAPL.meta)
     
-    @test AAPL[101:121] == AAPL2[1:end]
- nd    
+    @fact AAPL[101] --> AAPL2[1]
+    @fact AAPL[121] --> AAPL2[end]
+end    
 
 facts("construction without colnames") do
 


### PR DESCRIPTION
allows TimeArrays to be constructed from view_s of another TimeArray's timestamps
just as TimeArrays can be constructed from view_s of another TimeArray's values