### PR TITLE
combine: `hcat` support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,14 @@
   map(t, ta)
   ```
 
+* `hcat` support. Given two `TimeArray` which have same timestamp,
+
+  ```julia
+    [ta1 ta2]
+  ```
+
+  can perform faster than ```merge(ta1, ta2)``` in this case. (issue #TBD)
+
 ### 0.10.0
 
 * add support for time series plotting via RecipesBase dependency (thank you @mkborregaard) 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -1,4 +1,4 @@
-import Base: merge, vcat, map
+import Base: merge, hcat, vcat, map
 
 ###### merge ####################
 
@@ -48,6 +48,25 @@ function merge(ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, method::Symbol=
     return setcolnames!(ta, colnames)
 
 end
+
+# hcat ##########################
+
+function hcat(x::TimeArray, y::TimeArray)
+    tsx = x.timestamp
+    tsy = y.timestamp
+
+    if length(tsx) != length(tsx) || tsx != tsy
+        throw(DimensionMismatch(
+            "timestamps not consistent, please checkout `merge`."))
+    end
+
+    meta = ifelse(x.meta == y.meta, x.meta, nothing)
+
+    TimeArray(tsx, [x.values y.values], [x.colnames; y.colnames], meta)
+end
+
+hcat(x::TimeArray, y::TimeArray, zs::Vararg{TimeArray}) =
+    hcat(hcat(x, y), zs...)
 
 # collapse ######################
 

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -125,6 +125,28 @@ end
 end
 
 
+@testset "hcat" begin
+    let ta = [cl op cl]
+        @test ta.meta == cl.meta
+        @test length(ta.colnames) == 3
+        @test ta.colnames[1] != ta.colnames[3]
+        @test ta.colnames[1] == "Close"
+        @test ta.colnames[2] == "Open"
+        @test ta.values == [cl.values op.values cl.values]
+    end
+
+    let ta = [cl ohlc]
+        @test ta.meta == ta.meta
+        @test length(ta.colnames) == 5
+        @test ta.colnames[1] == "Close"
+        @test ta.colnames[1] != ta.colnames[end]
+        @test ta.values == [cl.values ohlc.values]
+    end
+
+    @test_throws DimensionMismatch [cl[1:3] cl]
+end
+
+
 @testset "vcat works correctly" begin
     @testset "concatenates time series correctly in 1D" begin
         a = TimeArray([Date(2015, 10, 01), Date(2015, 11, 01)], [15, 16], ["Number"])


### PR DESCRIPTION
For simple use case, it's faster than `merge`.
(`merge` serves as inner / outer join, which differs from `hcat`)

```julia
julia> @benchmark merge($cl, $ohlc)
BenchmarkTools.Trial:
  memory estimate:  210.75 KiB
  allocs estimate:  5122
  --------------
  minimum time:     273.470 μs (0.00% GC)
  median time:      279.141 μs (0.00% GC)
  mean time:        299.841 μs (5.72% GC)
  maximum time:     2.998 ms (79.71% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark [$cl $ohlc]
BenchmarkTools.Trial:
  memory estimate:  58.14 KiB
  allocs estimate:  1360
  --------------
  minimum time:     77.604 μs (0.00% GC)
  median time:      80.881 μs (0.00% GC)
  mean time:        102.880 μs (6.02% GC)
  maximum time:     5.132 ms (90.05% GC)
  --------------
  samples:          10000
  evals/sample:     1
```