### PR TITLE
Higher order differences for diff function

### DIFF
--- a/docs/src/apply.md
+++ b/docs/src/apply.md
@@ -60,6 +60,22 @@ put the last observation in the object (which happens to be on Dec 31,
 lead(cl, 499)
 ```
 
+## `diff`
+
+Differentiating a time series calculates the finite difference between
+two consecutive points in the time series. The resulting time series
+will have less points than the original. Those points are filled with
+`NaN` values if `padding=true`.
+
+```@repl diff
+diff(cl)
+```
+
+You can calculate higher order differences by using the keyword
+parameter `differences`, accepting a positive integer. The default
+value is `differences=1`. For instance, passing `differences=2` is
+equivalent to doing `diff(diff(cl)`. 
+
 ## `percentchange`
 
 Calculating change between timestamps is a very common time series

--- a/docs/src/apply.md
+++ b/docs/src/apply.md
@@ -68,6 +68,8 @@ will have less points than the original. Those points are filled with
 `NaN` values if `padding=true`.
 
 ```@repl diff
+using TimeSeries
+using MarketData
 diff(cl)
 ```
 

--- a/docs/src/apply.md
+++ b/docs/src/apply.md
@@ -74,7 +74,7 @@ diff(cl)
 You can calculate higher order differences by using the keyword
 parameter `differences`, accepting a positive integer. The default
 value is `differences=1`. For instance, passing `differences=2` is
-equivalent to doing `diff(diff(cl)`. 
+equivalent to doing `diff(diff(cl)`.
 
 ## `percentchange`
 

--- a/docs/src/apply.md
+++ b/docs/src/apply.md
@@ -74,7 +74,7 @@ diff(cl)
 You can calculate higher order differences by using the keyword
 parameter `differences`, accepting a positive integer. The default
 value is `differences=1`. For instance, passing `differences=2` is
-equivalent to doing `diff(diff(cl)`.
+equivalent to doing `diff(diff(cl))`.
 
 ## `percentchange`
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -48,10 +48,11 @@ end  # lead
 
 ###### diff #####################
 
-# TODO: Support higher-order differencing?
-function diff(ta::TimeArray; padding::Bool=false)
+function diff(ta::TimeArray; padding::Bool=false, differences::Int=1)
     cols = ta.colnames
-    ta = ta .- lag(ta, padding=padding)
+    for d in 1:differences
+        ta = ta .- lag(ta, padding=padding)
+    end
     ta.colnames[:] = cols
     return ta
 end  # diff

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -77,8 +77,8 @@ using TimeSeries
         @test diff(diff(op)).timestamp                        == diff(op, padding=false, differences=2).timestamp
         @test diff(diff(op)).values                           == diff(op, padding=false, differences=2).values
         @test diff(op, padding=true, differences=2).values[3] == diff(op, differences=2).values[1]
-        @test isequal(diff(op, padding=true, differences[2]).values[2], NaN)  == true
-        @test isequal(diff(op, padding=true, differences[2]).values[1], NaN)  == true
+        @test isequal(diff(op, padding=true, differences=2).values[2], NaN)  == true
+        @test isequal(diff(op, padding=true, differences=2).values[1], NaN)  == true
     end
 
     @testset "diff calculates 2nd-order differences for multi-column ts" begin
@@ -97,9 +97,9 @@ using TimeSeries
         @test diff(diff(diff(op))).timestamp                  == diff(op, padding=false, differences=3).timestamp
         @test diff(diff(diff(op))).values                     == diff(op, padding=false, differences=3).values
         @test diff(op, padding=true, differences=3).values[4] == diff(op, differences=3).values[1]
-        @test isequal(diff(op, padding=true, differences[2]).values[3], NaN)  == true
-        @test isequal(diff(op, padding=true, differences[2]).values[2], NaN)  == true
-        @test isequal(diff(op, padding=true, differences[2]).values[1], NaN)  == true
+        @test isequal(diff(op, padding=true, differences=3).values[3], NaN)  == true
+        @test isequal(diff(op, padding=true, differences=3).values[2], NaN)  == true
+        @test isequal(diff(op, padding=true, differences=3).values[1], NaN)  == true
     end
 
     @testset "diff calculates 3rd-order differences for multi-column ts" begin

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -62,6 +62,22 @@ using TimeSeries
         @test diff(op, padding=true).values[2]                == op[2].values[1] .- op[1].values[1]
     end
 
+    @testset "diff calculates 2nd-order differences" begin
+        @test diff(op, differences=2).timestamp               == diff(op, padding=false, differences=2).timestamp
+        @test diff(op, differences=2).values                  == diff(op, padding=false, differences=2).values
+        @test diff(diff(op)).timestamp                        == diff(op, padding=false, differences=2).timestamp
+        @test diff(diff(op)).values                           == diff(op, padding=false, differences=2).values
+        @test diff(op, padding=true, differences=2).values[3] == diff(op, differences=2).values[1]
+    end
+
+    @testset "diff calculates 3rd-order differences" begin
+        @test diff(op, differences=3).timestamp               == diff(op, padding=false, differences=3).timestamp
+        @test diff(op, differences=3).values                  == diff(op, padding=false, differences=3).values
+        @test diff(diff(diff(op))).timestamp                  == diff(op, padding=false, differences=3).timestamp
+        @test diff(diff(diff(op))).values                     == diff(op, padding=false, differences=3).values
+        @test diff(op, padding=true, differences=3).values[4] == diff(op, differences=3).values[1]
+    end
+
     @testset "simple return value" begin
         @test percentchange(cl, :simple).values == percentchange(cl).values
         @test percentchange(cl).values          == percentchange(cl, padding=false).values

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -86,7 +86,7 @@ using TimeSeries
         @test diff(ohlc, differences=2).values                         == diff(ohlc, padding=false, differences=2).values
         @test diff(diff(ohlc)).timestamp                               == diff(ohlc, padding=false, differences=2).timestamp
         @test diff(diff(ohlc)).values                                  == diff(ohlc, padding=false, differences=2).values
-        @test diff(ohlc, padding=true, differences=2).values[2,:]       == diff(ohlc, differences=2).values[1,:]
+        @test diff(ohlc, padding=true, differences=2).values[3,:]       == diff(ohlc, differences=2).values[1,:]
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=2).values[2,:]) == true
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=2).values[1,:]) == true
     end
@@ -107,7 +107,7 @@ using TimeSeries
         @test diff(ohlc, differences=3).values                         == diff(ohlc, padding=false, differences=3).values
         @test diff(diff(diff(ohlc))).timestamp                         == diff(ohlc, padding=false, differences=3).timestamp
         @test diff(diff(diff(ohlc))).values                            == diff(ohlc, padding=false, differences=3).values
-        @test diff(ohlc, padding=true, differences=3).values[3,:]      == diff(ohlc, differences=3).values[1,:]
+        @test diff(ohlc, padding=true, differences=3).values[4,:]      == diff(ohlc, differences=3).values[1,:]
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[3,:]) == true
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[2,:]) == true
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[1,:]) == true

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -62,12 +62,33 @@ using TimeSeries
         @test diff(op, padding=true).values[2]                == op[2].values[1] .- op[1].values[1]
     end
 
+    @testset "diff calculates 1st-order differences for multi-column ts" begin
+        @test diff(ohlc).timestamp                                     == diff(ohlc, padding=false).timestamp
+        @test diff(ohlc).values                                        == diff(ohlc, padding=false).values
+        @test diff(ohlc, padding=false).values[1,:]                    == ohlc.values[2,:] .- ohlc.values[1,:]
+        @test all(x -> isnan(x), diff(ohlc, padding=true).values[1,:]) == true
+        @test diff(ohlc, padding=true).values[2,:]                     == diff(ohlc).values[1,:]
+        @test diff(ohlc, padding=true).values[2,:]                     == ohlc.values[2,:] .- ohlc.values[1,:]
+    end
+
     @testset "diff calculates 2nd-order differences" begin
         @test diff(op, differences=2).timestamp               == diff(op, padding=false, differences=2).timestamp
         @test diff(op, differences=2).values                  == diff(op, padding=false, differences=2).values
         @test diff(diff(op)).timestamp                        == diff(op, padding=false, differences=2).timestamp
         @test diff(diff(op)).values                           == diff(op, padding=false, differences=2).values
         @test diff(op, padding=true, differences=2).values[3] == diff(op, differences=2).values[1]
+        @test isequal(diff(op, padding=true, differences[2]).values[2], NaN)  == true
+        @test isequal(diff(op, padding=true, differences[2]).values[1], NaN)  == true
+    end
+
+    @testset "diff calculates 2nd-order differences for multi-column ts" begin
+        @test diff(ohlc, differences=2).timestamp                      == diff(ohlc, padding=false, differences=2).timestamp
+        @test diff(ohlc, differences=2).values                         == diff(ohlc, padding=false, differenes=2).values
+        @test diff(diff(ohlc)).timestamp                               == diff(ohlc, padding=false, differences=2).timestamp
+        @test diff(diff(ohlc)).values                                  == diff(ohlc, padding=false, differences=2).values
+        @test diff(ohlc, padding=true, differences=2).values[2,:]       == diff(ohlc, differences=2).values[1,:]
+        @test all(x -> isnan(x), diff(ohlc, padding=true, differences=2).values[2,:]) == true
+        @test all(x -> isnan(x), diff(ohlc, padding=true, differences=2).values[1,:]) == true
     end
 
     @testset "diff calculates 3rd-order differences" begin
@@ -76,6 +97,20 @@ using TimeSeries
         @test diff(diff(diff(op))).timestamp                  == diff(op, padding=false, differences=3).timestamp
         @test diff(diff(diff(op))).values                     == diff(op, padding=false, differences=3).values
         @test diff(op, padding=true, differences=3).values[4] == diff(op, differences=3).values[1]
+        @test isequal(diff(op, padding=true, differences[2]).values[3], NaN)  == true
+        @test isequal(diff(op, padding=true, differences[2]).values[2], NaN)  == true
+        @test isequal(diff(op, padding=true, differences[2]).values[1], NaN)  == true
+    end
+
+    @testset "diff calculates 3rd-order differences for multi-column ts" begin
+        @test diff(ohlc, differences=3).timestamp                      == diff(ohlc, padding=false, differences=3).timestamp
+        @test diff(ohlc, differences=3).values                         == diff(ohlc, padding=false, differenes=3).values
+        @test diff(diff(diff(ohlc))).timestamp                         == diff(ohlc, padding=false, differences=3).timestamp
+        @test diff(diff(diff(ohlc))).values                            == diff(ohlc, padding=false, differences=3).values
+        @test diff(ohlc, padding=true, differences=3).values[3,:]      == diff(ohlc, differences=2).values[1,:]
+        @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[3,:]) == true
+        @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[2,:]) == true
+        @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[1,:]) == true
     end
 
     @testset "simple return value" begin

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -104,10 +104,10 @@ using TimeSeries
 
     @testset "diff calculates 3rd-order differences for multi-column ts" begin
         @test diff(ohlc, differences=3).timestamp                      == diff(ohlc, padding=false, differences=3).timestamp
-        @test diff(ohlc, differences=3).values                         == diff(ohlc, padding=false, differenes=3).values
+        @test diff(ohlc, differences=3).values                         == diff(ohlc, padding=false, differences=3).values
         @test diff(diff(diff(ohlc))).timestamp                         == diff(ohlc, padding=false, differences=3).timestamp
         @test diff(diff(diff(ohlc))).values                            == diff(ohlc, padding=false, differences=3).values
-        @test diff(ohlc, padding=true, differences=3).values[3,:]      == diff(ohlc, differences=2).values[1,:]
+        @test diff(ohlc, padding=true, differences=3).values[3,:]      == diff(ohlc, differences=3).values[1,:]
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[3,:]) == true
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[2,:]) == true
         @test all(x -> isnan(x), diff(ohlc, padding=true, differences=3).values[1,:]) == true

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -83,7 +83,7 @@ using TimeSeries
 
     @testset "diff calculates 2nd-order differences for multi-column ts" begin
         @test diff(ohlc, differences=2).timestamp                      == diff(ohlc, padding=false, differences=2).timestamp
-        @test diff(ohlc, differences=2).values                         == diff(ohlc, padding=false, differenes=2).values
+        @test diff(ohlc, differences=2).values                         == diff(ohlc, padding=false, differences=2).values
         @test diff(diff(ohlc)).timestamp                               == diff(ohlc, padding=false, differences=2).timestamp
         @test diff(diff(ohlc)).values                                  == diff(ohlc, padding=false, differences=2).values
         @test diff(ohlc, padding=true, differences=2).values[2,:]       == diff(ohlc, differences=2).values[1,:]


### PR DESCRIPTION
This pull request adds a new parameter `differences` to the `diff` function, to calculate higher order differences. The default value is `1`, so this change is backwards compatible.