### PR TITLE
Some alternatives to deprecated operators are wrongly displayed

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -24,14 +24,14 @@ for f ∈ (:abs, :sign, :sqrt, :cbrt,
 end
 
 for f ∈ (:^, :/)
-    g = Symbol("." * string(f))
+    g = Symbol(".", string(f))
     @eval import Base: $f
     @eval @deprecate $f(ta::TimeArray, args...) $g(ta, args...)
 end
 
 for f ∈ (:+, :-, :*, :%,
          :|, :&, :<, :>, :(==), :(!=), :>=, :<=)
-    g = Symbol("." * string(f))
+    g = Symbol(".", string(f))
     @eval import Base: $f
     @eval @deprecate $f(ta::TimeArray, args...) $g(ta, args...)
     @eval @deprecate $f(n::Number, ta::TimeArray) $g(n, ta)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -13,7 +13,7 @@ using Base: @deprecate
 # since julia 0.6
 
 # deprecate non-dot function due to 0.6 syntactic loop fusion
-for f ∈ (:^, :/, :abs, :sign, :sqrt, :cbrt,
+for f ∈ (:abs, :sign, :sqrt, :cbrt,
          :log, :log2, :log10, :log1p,
          :exp, :exp2, :exp10, :expm1,
          :cos, :sin, :tan, :cosd, :sind, :tand,
@@ -23,11 +23,16 @@ for f ∈ (:^, :/, :abs, :sign, :sqrt, :cbrt,
     @eval @deprecate $f(ta::TimeArray, args...) $f.(ta, args...)
 end
 
+for f ∈ (:^, :/)
+    @eval import Base: $f
+    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", $f)(ta, args...)
+end
+
 for f ∈ (:+, :-, :*, :%,
          :|, :&, :<, :>, :(==), :(!=), :>=, :<=)
     @eval import Base: $f
-    @eval @deprecate $f(ta::TimeArray, args...) $f.(ta, args...)
-    @eval @deprecate $f(n::Number, ta::TimeArray) $f.(n, ta)
+    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", $f)(ta, args...)
+    @eval @deprecate $f(n::Number, ta::TimeArray) Symbol(".", $f)(n, ta)
 end
 
 # non-dot operators

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -24,15 +24,17 @@ for f ∈ (:abs, :sign, :sqrt, :cbrt,
 end
 
 for f ∈ (:^, :/)
+    g = Symbol("." * string(f))
     @eval import Base: $f
-    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", f)(ta, args...)
+    @eval @deprecate $f(ta::TimeArray, args...) $g(ta, args...)
 end
 
 for f ∈ (:+, :-, :*, :%,
          :|, :&, :<, :>, :(==), :(!=), :>=, :<=)
+    g = Symbol("." * string(f))
     @eval import Base: $f
-    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", f)(ta, args...)
-    @eval @deprecate $f(n::Number, ta::TimeArray) Symbol(".", f)(n, ta)
+    @eval @deprecate $f(ta::TimeArray, args...) $g(ta, args...)
+    @eval @deprecate $f(n::Number, ta::TimeArray) $g(n, ta)
 end
 
 # non-dot operators

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -25,14 +25,14 @@ end
 
 for f ∈ (:^, :/)
     @eval import Base: $f
-    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", $f)(ta, args...)
+    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", f)(ta, args...)
 end
 
 for f ∈ (:+, :-, :*, :%,
          :|, :&, :<, :>, :(==), :(!=), :>=, :<=)
     @eval import Base: $f
-    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", $f)(ta, args...)
-    @eval @deprecate $f(n::Number, ta::TimeArray) Symbol(".", $f)(n, ta)
+    @eval @deprecate $f(ta::TimeArray, args...) Symbol(".", f)(ta, args...)
+    @eval @deprecate $f(n::Number, ta::TimeArray) Symbol(".", f)(n, ta)
 end
 
 # non-dot operators


### PR DESCRIPTION
In the deprecation warning, the message suggests to change operators such as `==` by `==.` (trailing dot), when the actual operator is `.==` (leading dot).

This pull request reports the correct names for those operators.