### PR TITLE
Add copy function to TimeArray

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -1,7 +1,7 @@
 ###### type definition ##########
 
-import Base: convert, length, show, getindex, start, next, done, isempty, endof,
-             size, eachindex
+import Base: convert, copy, length, show, getindex, start, next, done, isempty,
+             endof, size, eachindex
 
 abstract type AbstractTimeSeries end
 
@@ -55,6 +55,11 @@ convert(::Type{TimeArray{Float64, 2}}, x::TimeArray{Bool, 2}) =
 
 convert(x::TimeArray{Bool, 1}) = convert(TimeArray{Float64, 1}, x::TimeArray{Bool, 1})
 convert(x::TimeArray{Bool, 2}) = convert(TimeArray{Float64, 2}, x::TimeArray{Bool, 2})
+
+###### copy ###############
+
+copy(ta::TimeArray)::TimeArray =
+         TimeArray(ta.timestamp, ta.values, ta.colnames, ta.meta)
 
 ###### length ###################
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -59,7 +59,7 @@ convert(x::TimeArray{Bool, 2}) = convert(TimeArray{Float64, 2}, x::TimeArray{Boo
 ###### copy ###############
 
 copy(ta::TimeArray)::TimeArray =
-         TimeArray(ta.timestamp, ta.values, ta.colnames, ta.meta)
+    TimeArray(ta.timestamp, ta.values, ta.colnames, ta.meta)
 
 ###### length ###################
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -121,6 +121,20 @@ end
     end
 end
 
+@testset "copy methods" begin
+    cop = copy(op)
+    cohlc = copy(ohlc)
+    @testset "copy works" begin
+        @test cop.timestamp == op.timestamp
+        @test cop.values == op.values
+        @test cop.colnames == op.colnames
+        @test cop.meta == op.meta
+        @test cohlc.timestamp == ohlc.timestamp
+        @test cohlc.values == ohlc.values
+        @test cohlc.colnames == ohlc.colnames
+        @test cohlc.meta == ohlc.meta
+    end
+end
 
 @testset "index by integer works with both 1d and 2d time array" begin
     @testset "1d time array" begin


### PR DESCRIPTION
The copy base function is necessary to use the [Bootstrap package](https://github.com/juliangehring/Bootstrap.jl).

The Bootstrap package will also need some changes, but this paves the way to being able to use both packages together.