### PR TITLE
timearray: Revoke deprecation of `==` and redefine its meaning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 ### 0.12.0
 
 * Revoking deprecation warning of `==` and redefining its meaning as
-  'comparing all fields of two TimeArray'. (#356, #357)
+  'comparing all fields of two `TimeArray`s'.
+  Note that if two `TimeArray`s have different dimension, we consider that is
+  unequal.
+  (#356, #357)
 
   ```julia
   julia> cl == copy(cl)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+### 0.12.0
+
+* Revoking deprecation warning of `==` and redefining its meaning as
+  'comparing all fields of two TimeArray'. (#356, #TBD)
+
+  ```julia
+  julia> cl == copy(cl)
+  true
+  ```
+
 ### 0.11.0
 
 * Dropping 0.5 support. (issue [#327])

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,24 @@
 ### 0.12.0
 
 * Revoking deprecation warning of `==` and redefining its meaning as
-  'comparing all fields of two TimeArray'. (#356, #TBD)
+  'comparing all fields of two TimeArray'. (#356, #357)
 
   ```julia
   julia> cl == copy(cl)
   true
   ```
+
+  * Also, `isequal` and `hash` is supported now.
+
+    ```julia
+    julia> d = Dict(cl => 42);
+
+    julia> d[cl]
+    42
+
+    julia> d[copy(cl)]
+    42
+    ```
 
 ### 0.11.0
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -30,7 +30,7 @@ for f ∈ (:^, :/)
 end
 
 for f ∈ (:+, :-, :*, :%,
-         :|, :&, :<, :>, :(==), :(!=), :>=, :<=)
+         :|, :&, :<, :>, :>=, :<=)
     g = Symbol(".", string(f))
     @eval import Base: $f
     @eval @deprecate $f(ta::TimeArray, args...) $g(ta, args...)

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -78,6 +78,20 @@ isempty(ta::TimeArray) = (length(ta) == 0)
 
 ###### equal ####################
 
+"""
+    ==(x::TimeArray, y::TimeArray)
+
+If true, all fields of x and y should be equal.
+
+Implies
+
+```julia
+x.timestamp == y.timestamp &&
+x.values    == y.values    &&
+x.colnames  == y.colnames  &&
+x.meta      == y.meta
+```
+"""
 @generated function ==(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
   if N != M
     return :false

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -95,20 +95,20 @@ x.meta      == y.meta
 ```
 """
 @generated function ==(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
-  if N != M
-    return :false
-    # Other type info is not helpful for assertion.
-    # e.g.
-    #      1.0 == 1
-    #      Date(2111, 1, 1) == DateTime(2111, 1, 1)
-  end
-
-  quote
-    for f ∈ fieldnames(TimeArray)
-      getfield(x, f) != getfield(y, f) && return :false
+    if N != M
+        return :false
+        # Other type info is not helpful for assertion.
+        # e.g.
+        #      1.0 == 1
+        #      Date(2111, 1, 1) == DateTime(2111, 1, 1)
     end
-    :true
-  end
+
+    quote
+        for f ∈ fieldnames(TimeArray)
+            getfield(x, f) != getfield(y, f) && return :false
+        end
+        :true
+    end
 end
 
 ###### show #####################

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -1,7 +1,7 @@
 ###### type definition ##########
 
 import Base: convert, copy, length, show, getindex, start, next, done, isempty,
-             endof, size, eachindex
+             endof, size, eachindex, ==
 
 abstract type AbstractTimeSeries end
 
@@ -69,12 +69,31 @@ length(ata::AbstractTimeSeries) = length(ata.timestamp)
 
 size(ta::TimeArray, dim...) = size(ta.values, dim...)
 
-###### iterator protocol #########
+###### iterator protocol ########
 
 start(ta::TimeArray)   = 1
 next(ta::TimeArray, i) = ((ta.timestamp[i], ta.values[i, :]), i + 1)
 done(ta::TimeArray, i) = (i > length(ta))
 isempty(ta::TimeArray) = (length(ta) == 0)
+
+###### equal ####################
+
+@generated function ==(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
+  if N != M
+    return :false
+    # Other type info is not helpful for assertion
+    # e.g.
+    #      1.0 == 1
+    #      Date(2111, 1, 1) == DateTime(2111, 1, 1)
+  end
+
+  quote
+    for f ∈ fieldnames(TimeArray)
+      getfield(x, f) != getfield(y, f) && return :false
+    end
+    :true
+  end
+end
 
 ###### show #####################
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -1,7 +1,7 @@
 ###### type definition ##########
 
 import Base: convert, copy, length, show, getindex, start, next, done, isempty,
-             endof, size, eachindex, ==
+             endof, size, eachindex, ==, isequal, hash
 
 abstract type AbstractTimeSeries end
 
@@ -110,6 +110,25 @@ x.meta      == y.meta
         :true
     end
 end
+
+@generated function isequal(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
+    if N != M
+      return :false
+    end
+
+    quote
+        for f ∈ fieldnames(TimeArray)
+          !isequal(getfield(x, f), getfield(y, f)) && return :false
+        end
+        :true
+    end
+end
+
+# support for Dict
+hash(x::TimeArray, h::UInt) =
+    mapreduce(+, fieldnames(TimeArray)) do f
+        hash(getfield(x, f), h)
+    end
 
 ###### show #####################
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -125,10 +125,7 @@ end
 end
 
 # support for Dict
-hash(x::TimeArray, h::UInt) =
-    mapreduce(+, fieldnames(TimeArray)) do f
-        hash(getfield(x, f), h)
-    end
+hash(x::TimeArray, h::UInt) = sum(f -> hash(getfield(x, f), h), fieldnames(TimeArray))
 
 ###### show #####################
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -81,7 +81,9 @@ isempty(ta::TimeArray) = (length(ta) == 0)
 """
     ==(x::TimeArray, y::TimeArray)
 
-If true, all fields of x and y should be equal.
+If `true`, all fields of `x` and `y` should be equal,
+meaning that the two `TimeArray`s have the same values at the same points in time,
+the same colnames and the same metadata.
 
 Implies
 
@@ -95,7 +97,7 @@ x.meta      == y.meta
 @generated function ==(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
   if N != M
     return :false
-    # Other type info is not helpful for assertion
+    # Other type info is not helpful for assertion.
     # e.g.
     #      1.0 == 1
     #      Date(2111, 1, 1) == DateTime(2111, 1, 1)

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -94,38 +94,21 @@ x.colnames  == y.colnames  &&
 x.meta      == y.meta
 ```
 """
-@generated function ==(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
-    if N != M
-        return :false
-        # Other type info is not helpful for assertion.
-        # e.g.
-        #      1.0 == 1
-        #      Date(2111, 1, 1) == DateTime(2111, 1, 1)
-    end
+# Other type info is not helpful for assertion.
+# e.g.
+#      1.0 == 1
+#      Date(2111, 1, 1) == DateTime(2111, 1, 1)
+==(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M} = false
+==(x::TimeArray{T,N}, y::TimeArray{S,N}) where {T,S,N} =
+    all(f -> getfield(x, f) == getfield(y, f), fieldnames(TimeArray))
 
-    quote
-        for f ∈ fieldnames(TimeArray)
-            getfield(x, f) != getfield(y, f) && return :false
-        end
-        :true
-    end
-end
-
-@generated function isequal(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M}
-    if N != M
-      return :false
-    end
-
-    quote
-        for f ∈ fieldnames(TimeArray)
-          !isequal(getfield(x, f), getfield(y, f)) && return :false
-        end
-        :true
-    end
-end
+isequal(x::TimeArray{T,N}, y::TimeArray{S,M}) where {T,S,N,M} = false
+isequal(x::TimeArray{T,N}, y::TimeArray{S,N}) where {T,S,N} =
+    all(f -> isequal(getfield(x, f), getfield(y, f)), fieldnames(TimeArray))
 
 # support for Dict
-hash(x::TimeArray, h::UInt) = sum(f -> hash(getfield(x, f), h), fieldnames(TimeArray))
+hash(x::TimeArray, h::UInt) =
+    sum(f -> hash(getfield(x, f), h), fieldnames(TimeArray))
 
 ###### show #####################
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -242,8 +242,12 @@ end
 
 @testset "equal" begin
     @test cl == copy(cl)
-    @test cl != ohlc  # rely on fallback definition
-    @test cl != lag(cl)
+    @test cl ≠ ohlc  # rely on fallback definition
+    @test cl ≠ lag(cl)
+
+    @test isequal(cl, copy(cl))
+    @test !isequal(cl, ohlc)
+    @test !isequal(cl, lag(cl))
 
     ds = DateTime(2017, 12, 25):DateTime(2017, 12, 31) |> collect
 
@@ -263,6 +267,15 @@ end
         ds2 = Date(2017, 12, 25):Date(2017, 12, 31) |> collect
         x = TimeArray(ds,  1:7, ["foo"], "bar")
         y = TimeArray(ds2, 1:7, ["foo"], "bar")
+        @test x == y
+    end
+
+    @testset "hash" begin
+        @test hash(cl) == hash(copy(cl))
+
+        d = Dict(cl => 42)
+        @test d[cl] == 42
+        @test d[copy(cl)] == 42
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -248,21 +248,21 @@ end
     ds = DateTime(2017, 12, 25):DateTime(2017, 12, 31) |> collect
 
     let  # diff colnames
-      x = TimeArray(ds, 1:7, ["foo"])
-      y = TimeArray(ds, 1:7, ["bar"])
-      @test x != y
+        x = TimeArray(ds, 1:7, ["foo"])
+        y = TimeArray(ds, 1:7, ["bar"])
+        @test x != y
     end
 
     let  # Float vs Int
-      x = TimeArray(ds, 1:7)
-      y = TimeArray(ds, 1.0:7)
-      @test x == y
+        x = TimeArray(ds, 1:7)
+        y = TimeArray(ds, 1.0:7)
+        @test x == y
     end
 
     let  # Date vs DateTime
-      ds2 = Date(2017, 12, 25):Date(2017, 12, 31) |> collect
-      x = TimeArray(ds,  1:7, ["foo"], "bar")
-      y = TimeArray(ds2, 1:7, ["foo"], "bar")
+        ds2 = Date(2017, 12, 25):Date(2017, 12, 31) |> collect
+        x = TimeArray(ds,  1:7, ["foo"], "bar")
+        y = TimeArray(ds2, 1:7, ["foo"], "bar")
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -240,6 +240,33 @@ end
 end
 
 
+@testset "equal" begin
+    @test cl == copy(cl)
+    @test cl != ohlc  # rely on fallback definition
+    @test cl != lag(cl)
+
+    ds = DateTime(2017, 12, 25):DateTime(2017, 12, 31) |> collect
+
+    let  # diff colnames
+      x = TimeArray(ds, 1:7, ["foo"])
+      y = TimeArray(ds, 1:7, ["bar"])
+      @test x != y
+    end
+
+    let  # Float vs Int
+      x = TimeArray(ds, 1:7)
+      y = TimeArray(ds, 1.0:7)
+      @test x == y
+    end
+
+    let  # Date vs DateTime
+      ds2 = Date(2017, 12, 25):Date(2017, 12, 31) |> collect
+      x = TimeArray(ds,  1:7, ["foo"], "bar")
+      y = TimeArray(ds2, 1:7, ["foo"], "bar")
+    end
+end
+
+
 @testset "show methods don't throw errors" begin
     let str = sprint(show, cl)
         out = """500x1 TimeSeries.TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -270,12 +270,23 @@ end
         @test x == y
     end
 
+    let  # diff meta
+        x = TimeArray(ds, 1:7, ["foo"], "bar")
+        y = TimeArray(ds, 1:7, ["foo"], "baz")
+        @test x != y
+    end
+
     @testset "hash" begin
-        @test hash(cl) == hash(copy(cl))
+        @test hash(cl)   == hash(copy(cl))
+        @test hash(ohlc) == hash(copy(ohlc))
 
         d = Dict(cl => 42)
         @test d[cl] == 42
         @test d[copy(cl)] == 42
+
+        d = Dict(ohlc => 24)
+        @test d[ohlc] == 24
+        @test d[copy(ohlc)] == 24
     end
 end
 


### PR DESCRIPTION
```julia
julia> cl == copy(cl)
true
```

---

@dourouc05 please review this