### PR TITLE
Construct opt

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -23,8 +23,11 @@ struct TimeArray{T, N, D <: TimeType, A <: AbstractArray{T, N}} <: AbstractTimeS
             timestamp::AbstractVector{D},
             values::A,
             colnames::Vector{String},
-            meta::Any) where {T, N, D <: TimeType, A <: AbstractArray{T, N}}
+            meta::Any;
+            unchecked = false) where {T, N, D <: TimeType, A <: AbstractArray{T, N}}
         nrow, ncol = size(values, 1, 2)
+
+        unchecked && return new(timestamp, values, replace_dupes(colnames), meta)
 
         nrow != length(timestamp) && throw(DimensionMismatch("values must match length of timestamp"))
         ncol != length(colnames) && throw(DimensionMismatch("column names must match width of array"))
@@ -42,11 +45,13 @@ end
 
 TimeArray(d::AbstractVector{D}, v::AbstractArray{T, N},
           c::Vector{S}=fill("", size(v,2)),
-          m::Any=nothing) where {T, N, D <: TimeType, S <: AbstractString} =
-    TimeArray{T, N, D, typeof(v)}(d, v, map(String, c), m)
+          m::Any=nothing;
+          args...) where {T, N, D <: TimeType, S <: AbstractString} =
+    TimeArray{T, N, D, typeof(v)}(d, v, map(String, c), m; args...)
 TimeArray(d::D, v::AbstractArray{T, N}, c::Vector{S}=fill("", size(v, 2)),
-          m::Any=nothing) where {T, N, D <: TimeType, S <: AbstractString} =
-    TimeArray{T, N, D, typeof(v)}([d], v, map(String, c), m)
+          m::Any=nothing;
+          args...) where {T, N, D <: TimeType, S <: AbstractString} =
+    TimeArray{T, N, D, typeof(v)}([d], v, map(String, c), m; args...)
 
 ###### conversion ###############
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -5,6 +5,13 @@ import Base: convert, copy, length, show, getindex, start, next, done, isempty,
 
 abstract type AbstractTimeSeries end
 
+function _issorted_and_unique(x)
+    for i in 1:length(x)-1
+        @inbounds !(x[i] < x[i + 1]) && return false
+    end
+    true
+end
+
 struct TimeArray{T, N, D <: TimeType, A <: AbstractArray{T, N}} <: AbstractTimeSeries
 
     timestamp::Vector{D}
@@ -19,20 +26,15 @@ struct TimeArray{T, N, D <: TimeType, A <: AbstractArray{T, N}} <: AbstractTimeS
             meta::Any) where {T, N, D <: TimeType, A <: AbstractArray{T, N}}
         nrow, ncol = size(values, 1, 2)
 
-        if nrow != length(timestamp)
-            throw(DimensionMismatch("values must match length of timestamp"))
-        elseif ncol != length(colnames)
-            throw(DimensionMismatch("column names must match width of array"))
-        elseif !allunique(timestamp)
-            throw(ArgumentError("there are duplicate dates"))
-        elseif !(issorted(timestamp) || issorted(timestamp, rev=true))
-            throw(ArgumentError("dates are mangled"))
-        elseif issorted(timestamp, rev=true)
-            new(reverse(timestamp), flipdim(values, 1),
-                replace_dupes(colnames), meta)
-        else
-            new(timestamp, values, replace_dupes(colnames), meta)
-        end
+        nrow != length(timestamp) && throw(DimensionMismatch("values must match length of timestamp"))
+        ncol != length(colnames) && throw(DimensionMismatch("column names must match width of array"))
+
+        _issorted_and_unique(timestamp) && return new(timestamp, values, replace_dupes(colnames), meta)
+
+        timestamp_r = reverse(timestamp)
+        _issorted_and_unique(timestamp_r) && return new(timestamp_r, flipdim(values, 1), replace_dupes(colnames), meta)
+
+        throw(ArgumentError("timestamps must be strictly monotonic"))
     end
 end
 

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -93,8 +93,13 @@ end
         @test dupe_cnames.colnames[11] == "e_3"
         @test dupe_cnames.colnames[12] == "f"
     end
-end
 
+    @testset "and doesn't when unchecked" begin
+        @test TimeArray(mangled_stamp, cl.values; unchecked = true).values === cl.values
+        @test TimeArray(mangled_stamp, cl.values; unchecked = true).timestamp === mangled_stamp
+        @test TimeArray(dupe_stamp, cl.values; unchecked = true).timestamp === dupe_stamp
+    end
+end
 
 @testset "construction without colnames" begin
     no_colnames_one   = TimeArray(cl.timestamp, cl.values)


### PR DESCRIPTION
I've been trying to use ```TimeSeries.jl``` on some high frequency datasets and ran into some performance bottlenecks in ```TimeArray``` construction. In particular the uniqueness test is heavy.

I've made a couple of changes here that help my use cases:
* Check sorted and uniqueness in one pass, allocation free.
* Add option to disable construction checks entirely.

Rough performance improvements for something on the scale of my use case, 10 million entries, 1 column:
* Previous: ~4 seconds
* New: ~8ms
* New unchecked: ~20us

If these changes look reasonable I have a few more I'd like to add. To extend this I'd change some of the algorithms to construct ```TimeArray``` objects unchecked. I also noticed a few places that don't handle ```Float32``` properly, and I'd like to rectify that.