### PR TITLE
merge() optimization

### DIFF
--- a/src/combine.jl
+++ b/src/combine.jl
@@ -35,10 +35,8 @@ function merge(ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, method::Symbol=
 
     elseif method == :outer
 
-        timestamps = sorted_unique_merge(ta1.timestamp, ta2.timestamp)
+        timestamps, new_idx1, new_idx2 = sorted_unique_merge(ta1.timestamp, ta2.timestamp)
         vals = fill(convert(T, missingvalue), (length(timestamps), length(ta1.colnames) + length(ta2.colnames)))
-        new_idx1 = sorted_subset_idx(timestamps, ta1.timestamp)
-        new_idx2 = sorted_subset_idx(timestamps, ta2.timestamp)
         insertbyidx!(vals, ta1.values, new_idx1)
         insertbyidx!(vals, ta2.values, new_idx2, size(ta1.values, 2))
         ta = TimeArray(timestamps, vals, [ta1.colnames; ta2.colnames], meta; unchecked = true)

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -2,16 +2,16 @@ import Base: merge, hcat, vcat, map
 
 ###### merge ####################
 
-function _merge_outer(::Type{IndexType}, ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, missingvalue, meta) where {IndexType, T, N, M, D}
+function _merge_outer(::Type{IndexType}, ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, padvalue, meta) where {IndexType, T, N, M, D}
     timestamps, new_idx1, new_idx2 = sorted_unique_merge(IndexType, ta1.timestamp, ta2.timestamp)
-    vals = fill(convert(T, missingvalue), (length(timestamps), length(ta1.colnames) + length(ta2.colnames)))
+    vals = fill(convert(T, padvalue), (length(timestamps), length(ta1.colnames) + length(ta2.colnames)))
     insertbyidx!(vals, ta1.values, new_idx1)
     insertbyidx!(vals, ta2.values, new_idx2, size(ta1.values, 2))
     TimeArray(timestamps, vals, [ta1.colnames; ta2.colnames], meta; unchecked = true)
 end
 
 function merge(ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, method::Symbol=:inner;
-               colnames::Vector=[], meta::Any=Void, missingvalue=NaN) where {T, N, M, D}
+               colnames::Vector=[], meta::Any=Void, padvalue=NaN) where {T, N, M, D}
 
     if ta1.meta == ta2.meta && meta == Void
         meta = ta1.meta
@@ -30,13 +30,13 @@ function merge(ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, method::Symbol=
     elseif method == :left
 
         new_idx2, old_idx2 = overlaps(ta1.timestamp, ta2.timestamp)
-        right_vals = fill(convert(T, missingvalue), (length(ta1), length(ta2.colnames)))
+        right_vals = fill(convert(T, padvalue), (length(ta1), length(ta2.colnames)))
         insertbyidx!(right_vals, ta2.values, new_idx2, old_idx2)
         ta = TimeArray(ta1.timestamp, [ta1.values right_vals], [ta1.colnames; ta2.colnames], meta; unchecked = true)
 
     elseif method == :right
 
-        ta = merge(ta2, ta1, :left; missingvalue = missingvalue)
+        ta = merge(ta2, ta1, :left; padvalue = padvalue)
         ncol2 = length(ta2.colnames)
         vals = [ta.values[:, (ncol2+1):end] ta.values[:, 1:ncol2]]
         ta = TimeArray(ta.timestamp, vals, [ta1.colnames; ta2.colnames], meta; unchecked = true)
@@ -44,9 +44,9 @@ function merge(ta1::TimeArray{T, N, D}, ta2::TimeArray{T, M, D}, method::Symbol=
     elseif method == :outer
 
         ta = if (length(ta1.timestamp) + length(ta2.timestamp)) > typemax(Int32)
-            _merge_outer(Int64, ta1, ta2, missingvalue, meta)
+            _merge_outer(Int64, ta1, ta2, padvalue, meta)
         else
-            _merge_outer(Int32, ta1, ta2, missingvalue, meta)
+            _merge_outer(Int32, ta1, ta2, padvalue, meta)
         end
 
     else

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -25,36 +25,91 @@ function overlaps(ts::Vararg{Vector, N}) where {N}
     ret
 end
 
-
 function sorted_unique_merge(a::Vector, b::Vector)
-
-		i, na, j, nb = 1, length(a), 1, length(b)
-		c = similar(a, 0)
-
-		while (i <= na) && (j <= nb)
-				if a[i] < b[j]
-						push!(c, a[i])
-						i += 1
-				elseif a[i] > b[j]
-						push!(c, b[j])
-						j += 1
-				else
-						push!(c, a[i])
-						i += 1
-						j += 1
-				end #if
+    i, na, j, nb = 1, length(a), 1, length(b)
+    c = similar(a, length(a) + length(b))
+    k = 1
+    @inbounds while (i <= na) && (j <= nb)
+		if a[i] < b[j]
+            c[k] = a[i]
+			i += 1
+		elseif a[i] > b[j]
+            c[k] = b[j]
+			j += 1
+		else
+            c[k] = a[i]
+			i += 1
+			j += 1
 		end
-
-		append!(c, a[i:end])
-		append!(c, b[j:end])
-
+        k += 1
+    end
+    while i <= na
+        @inbounds c[k] = a[i]
+        i += 1
+        k += 1
+    end
+    while j <= nb
+        @inbounds c[k] = b[j]
+        j += 1
+        k += 1
+    end
+    resize!(c, k - 1)
     return c
+end
 
-end  # sorted_unique_merge
+"""
+    sorted_subset_idx(superset, subset) -> indices
+
+Get indices in superset for elements in subset.
+"""
+function sorted_subset_idx(superset, subset)
+    subset_len = length(subset)
+    result = Vector{Int32}(subset_len)
+    new_i = 1
+    for i in 1:length(superset)
+        @inbounds if superset[i] == subset[new_i]
+            result[new_i] = i
+            new_i += 1
+            if new_i > subset_len
+                break
+            end
+        end
+    end
+    result
+end
+
+"""
+    insertbyidx!(dst, src, dstidx, coloffset = 0)
+
+For each column in src, insert elements from src[i, column] to dst[dstidx[i], column + coloffset].
+"""
+function insertbyidx!(dst::AbstractArray, src::AbstractArray, dstidx::Vector, coloffset::Int = 0)
+    for c in 1:size(src, 2)
+        cc = c + coloffset
+        for i in 1:length(dstidx)
+            @inbounds dst[dstidx[i], cc] = src[i, c]
+        end
+    end
+    nothing
+end
+
+"""
+    insertbyidx!(dst, src, dstidx, srcidx)
+
+For each column in src, insert elements from src[srcidx[i], column] to dst[dstidx[i], column].
+"""
+function insertbyidx!(dst::AbstractArray, src::AbstractArray, dstidx::Vector, srcidx::Vector)
+    for c in 1:size(src, 2)
+        for i in 1:length(srcidx)
+            @inbounds dst[dstidx[i], c] = src[srcidx[i], c]
+        end
+    end
+    nothing
+end
+
 
 function setcolnames!(ta::TimeArray, colnames::Vector)
     length(colnames) == length(ta.colnames) ? ta.colnames[:] = colnames :
     length(colnames) > 0 && error("colnames supplied is not correct size")
     return ta
 end  # setcolnames!
-

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -40,21 +40,21 @@ function sorted_unique_merge(::Type{IndexType}, a::Vector, b::Vector) where {Ind
     idx_b = Vector{IndexType}(length(b))
     k = 1
     @inbounds while (i <= na) && (j <= nb)
-		if a[i] < b[j]
+        if a[i] < b[j]
             c[k] = a[i]
             idx_a[i] = k
-			i += 1
-		elseif a[i] > b[j]
+            i += 1
+        elseif a[i] > b[j]
             c[k] = b[j]
             idx_b[j] = k
-			j += 1
-		else
+            j += 1
+        else
             c[k] = a[i]
             idx_a[i] = k
             idx_b[j] = k
-			i += 1
-			j += 1
-		end
+            i += 1
+            j += 1
+        end
         k += 1
     end
     @inbounds while i <= na

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -32,8 +32,6 @@ Merge two arrays of sorted unique elements a and b to new array c,
 and calculate the indexes idx_a and idx_b mapping each element in a and b to their new locations in c.
 """
 function sorted_unique_merge(::Type{IndexType}, a::Vector, b::Vector) where {IndexType}
-    # NOTE: Since merge is mostly load/store bound, the lower memory pressure from 32 bit indexing does help.
-    #       Would need to be reconsidered if datasets are larger, or branch the algorithm
     i, na, j, nb = 1, length(a), 1, length(b)
     c = similar(a, length(a) + length(b))
     idx_a = Vector{IndexType}(length(a))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -31,11 +31,13 @@ end
 Merge two arrays of sorted unique elements a and b to new array c,
 and calculate the indexes idx_a and idx_b mapping each element in a and b to their new locations in c.
 """
-function sorted_unique_merge(a::Vector, b::Vector)
+function sorted_unique_merge(::Type{IndexType}, a::Vector, b::Vector) where {IndexType}
+    # NOTE: Since merge is mostly load/store bound, the lower memory pressure from 32 bit indexing does help.
+    #       Would need to be reconsidered if datasets are larger, or branch the algorithm
     i, na, j, nb = 1, length(a), 1, length(b)
     c = similar(a, length(a) + length(b))
-    idx_a = Vector{Int32}(length(a))
-    idx_b = Vector{Int32}(length(b))
+    idx_a = Vector{IndexType}(length(a))
+    idx_b = Vector{IndexType}(length(b))
     k = 1
     @inbounds while (i <= na) && (j <= nb)
 		if a[i] < b[j]

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -126,13 +126,13 @@ end
     @testset "custom missing values" begin
         ts1 = TimeArray([Date(2018, 1, 1), Date(2018, 1, 2)], [1, 2])
         ts2 = TimeArray([Date(2018, 1, 2), Date(2018, 1, 3)], [3, 4])
-        m1 = merge(ts1, ts2, :left, missingvalue = 0)
+        m1 = merge(ts1, ts2, :left, padvalue = 0)
         @test m1.timestamp == [Date(2018, 1, 1), Date(2018, 1, 2)]
         @test m1.values == [1 0; 2 3]
-        m2 = merge(ts1, ts2, :right, missingvalue = 0)
+        m2 = merge(ts1, ts2, :right, padvalue = 0)
         @test m2.timestamp == [Date(2018, 1, 2), Date(2018, 1, 3)]
         @test m2.values == [2 3; 0 4]
-        m3 = merge(ts1, ts2, :outer, missingvalue = 0)
+        m3 = merge(ts1, ts2, :outer, padvalue = 0)
         @test m3.timestamp == [Date(2018, 1, 1), Date(2018, 1, 2), Date(2018, 1, 3)]
         @test m3.values == [1 0; 2 3; 0 4]
     end

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -122,6 +122,20 @@ end
     @testset "unknown method" begin
         @test_throws ArgumentError merge(cl, op, :unknown)
     end
+
+    @testset "custom missing values" begin
+        ts1 = TimeArray([Date(2018, 1, 1), Date(2018, 1, 2)], [1, 2])
+        ts2 = TimeArray([Date(2018, 1, 2), Date(2018, 1, 3)], [3, 4])
+        m1 = merge(ts1, ts2, :left, missingvalue = 0)
+        @test m1.timestamp == [Date(2018, 1, 1), Date(2018, 1, 2)]
+        @test m1.values == [1 0; 2 3]
+        m2 = merge(ts1, ts2, :right, missingvalue = 0)
+        @test m2.timestamp == [Date(2018, 1, 2), Date(2018, 1, 3)]
+        @test m2.values == [2 3; 0 4]
+        m3 = merge(ts1, ts2, :outer, missingvalue = 0)
+        @test m3.timestamp == [Date(2018, 1, 1), Date(2018, 1, 2), Date(2018, 1, 3)]
+        @test m3.values == [1 0; 2 3; 0 4]
+    end
 end
 
 


### PR DESCRIPTION
Summary:
* Unchecked construction of TimeArray objects.
* Direct implementation of outer join.
* Support for arbitrary types by user defined missing value.
* More optimal index based assignment than generic indexing operation (applies to left, right, and outer join).

Mostly focused on optimizing outer join. Benchmark example:

```Julia
using TimeSeries
using BenchmarkTools

struct SimpleTime <: Dates.TimeType
    value::Int64
end

Base.isless(x::SimpleTime, y::SimpleTime) = x.value < y.value
Base.isequal(x::SimpleTime, y::SimpleTime) = x.value == y.value
Base.:(==)(x::SimpleTime, y::SimpleTime) = x.value == y.value

t1 = [SimpleTime(x) for x in 1:2_000_000]
t2 = [SimpleTime(2 * x) for x in 1:2_000_000]
v1 = rand(Float64, length(t1), 10)
v2 = rand(Float64, length(t2), 10)
ts1 = TimeArray(t1, v1)
ts2 = TimeArray(t2, v2)
@btime merge(ts1, ts2, :outer)
```

Previous result:
```
  2.008 s (659 allocations: 1.97 GiB)
```

New result:
```
  415.149 ms (518 allocations: 503.57 MiB)
```

At these scales it's mostly load/store bound so any reduction in that (e.g. smaller index types, smaller data types, fewer passes) make the biggest difference. For my, and maybe other people's use cases ```Float32``` support helps a lot. The above benchmark with ```Float32``` values is ~224ms.