### PR TITLE
Swap adjoint for permutedims in collapse

### DIFF
--- a/src/combine.jl
+++ b/src/combine.jl
@@ -106,7 +106,7 @@ function collapse(ta::TimeArray{T,N,D}, period::Function, timestamp::Function,
 
         if mapped_tstamp != next_mapped_tstamp
           push!(collapsed_tstamps, timestamp(_timestamp(ta)[cluster_startrow:i]))
-          collapsed_values = [collapsed_values; T[value(values(ta)[cluster_startrow:i, j]) for j in 1:ncols]']
+          collapsed_values = [collapsed_values; T[value(values(ta)[cluster_startrow:i, j]) for j in 1:ncols] |> permutedims]
           cluster_startrow = i+1
         end #if
 
@@ -116,7 +116,7 @@ function collapse(ta::TimeArray{T,N,D}, period::Function, timestamp::Function,
     end #for
 
     push!(collapsed_tstamps, timestamp(_timestamp(ta)[cluster_startrow:end]))
-    collapsed_values = [collapsed_values; T[value(values(ta)[cluster_startrow:end, j]) for j in 1:ncols]']
+    collapsed_values = [collapsed_values; T[value(values(ta)[cluster_startrow:end, j]) for j in 1:ncols] |> permutedims]
 
     N == 1 && (collapsed_values = vec(collapsed_values))
     return TimeArray(collapsed_tstamps, collapsed_values, colnames(ta), meta(ta))

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -43,8 +43,8 @@ end
         let
             ta = collapse(ta, week, first)
 
-            @test values(ta[2])    == A[6]
-            @test timestamp(ta)[6] == A[6]
+            @test values(ta)[2]    == A[6]
+            @test timestamp(ta)[2] == ts[6]
         end
     end
 end

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -33,6 +33,20 @@ end
         @test values(collapse(ohlc, month, first))[2, :] == [104.0, 105.0, 100.0, 100.25]
         @test timestamp(collapse(ohlc, month, first))[2] == Date(2000,2,1)
     end
+
+    # https://github.com/JuliaStats/TimeSeries.jl/pull/397
+    @testset "Array of String" begin
+        A = string.(Char.(rand(97:97+25, size(cl))))
+        ts = timestamp(cl)
+        ta = TimeArray(ts, A)
+
+        let
+            ta = collapse(ta, week, first)
+
+            @test values(ta[2])    == A[6]
+            @test timestamp(ta)[6] == A[6]
+        end
+    end
 end
 
 


### PR DESCRIPTION
This allows collapse to be used with types for which adjoint is not defined, such as strings.

It also prevents complex numbers from being conjugated, which may have come as a surprise to users.