### PR TITLE
Revise show method for timearray

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -208,7 +208,7 @@ calculate the paging
     ret
 end
 
-function show(io::IO, ta::TimeArray{T}) where T
+function print_time_array(io::IO, ta::TimeArray{T}, short=false) where T
     # summary line
     nrow = size(values(ta), 1)
     ncol = size(values(ta), 2)
@@ -220,6 +220,7 @@ function show(io::IO, ta::TimeArray{T}) where T
         return
     end
 
+    if !short
     # calculate column withs
     drow, dcol = displaysize(io)
     res_row    = 7  # number of reserved rows: summary line, lable line ... etc
@@ -297,7 +298,11 @@ function show(io::IO, ta::TimeArray{T}) where T
             print(io, "\n\n")
         end
     end  # for p ∈ pages
+    end # if !short
 end
+Base.show(io::IO, ta::TimeSeries.TimeArray) = print_time_array(io, ta, true)
+Base.show(io::IO, ::MIME"text/plain", ta::TimeArray) = print_time_array(io, ta, false)
+
 
 ###### getindex #################
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -215,12 +215,13 @@ function print_time_array(io::IO, ta::TimeArray{T}, short=false) where T
 
     print(io, "$(nrow)×$(ncol) $(typeof(ta))")
     if nrow != 0
-        println(io, " $(timestamp(ta)[1]) to $(timestamp(ta)[end])")
+        print(io, " $(timestamp(ta)[1]) to $(timestamp(ta)[end])")
     else  # e.g. TimeArray(Date[], [])
         return
     end
 
     short && return
+    println(io)
 
     # calculate column withs
     drow, dcol = displaysize(io)

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -221,83 +221,83 @@ function print_time_array(io::IO, ta::TimeArray{T}, short=false) where T
     end
 
     if !short
-    # calculate column withs
-    drow, dcol = displaysize(io)
-    res_row    = 7  # number of reserved rows: summary line, lable line ... etc
-    half_row   = floor(Int, (drow - res_row) / 2)
-    add_row    = (drow - res_row) % 2
+        # calculate column withs
+        drow, dcol = displaysize(io)
+        res_row    = 7  # number of reserved rows: summary line, lable line ... etc
+        half_row   = floor(Int, (drow - res_row) / 2)
+        add_row    = (drow - res_row) % 2
 
-    if nrow > (drow - res_row)
-        tophalf = 1:(half_row + add_row)
-        bothalf = (nrow - half_row + 1):nrow
-        strs = _showval.(@view values(ta)[[tophalf; bothalf], :])
-        ts   = @view timestamp(ta)[[tophalf; bothalf]]
-    else
-        strs = _showval.(values(ta))
-        ts   = timestamp(ta)
-    end
-
-    colwidth = maximum(
-        [textwidth.(string.(colnames(ta)))'; textwidth.(strs); fill(5, ncol)'],
-        dims = 1)
-
-    # paging
-    spacetime = textwidth(string(ts[1]))
-    pages = _showpages(dcol, spacetime, colwidth)
-
-    for p ∈ pages
-        # row label line
-        ## e.g. | Open  | High  | Low   | Close  |
-        print(io, "│", " "^(spacetime + 2))
-        for (name, w) in zip(colnames(ta)[p], colwidth[p])
-            print(io, "│ ", rpad(name, w + 1))
-        end
-        println(io, "│")
-        ## e.g. ├───────┼───────┼───────┼────────┤
-        print(io, "├", "─"^(spacetime + 2))
-        for w in colwidth[p]
-            print(io, "┼", "─"^(w + 2))
-        end
-        print(io, "┤")
-
-        # timestamp and values line
         if nrow > (drow - res_row)
-            for i in tophalf
-                println(io)
-                print(io, "│ ", ts[i], " ")
-                for j in p
-                    print(io, "│ ", rpad(strs[i, j], colwidth[j] + 1))
-                end
-                print(io, "│")
-            end
-
-            print(io, "\n   \u22EE")
-
-            for i in (length(bothalf) - 1):-1:0
-                i = size(strs, 1) - i
-                println(io)
-                print(io, "│ ", ts[i], " ")
-                for j in p
-                    print(io, "│ ", rpad(strs[i, j], colwidth[j] + 1))
-                end
-                print(io, "│")
-            end
-
+            tophalf = 1:(half_row + add_row)
+            bothalf = (nrow - half_row + 1):nrow
+            strs = _showval.(@view values(ta)[[tophalf; bothalf], :])
+            ts   = @view timestamp(ta)[[tophalf; bothalf]]
         else
-            for i in 1:nrow
-                println(io)
-                print(io, "│ ", ts[i], " ")
-                for j in p
-                    print(io, "│ ", rpad(strs[i, j], colwidth[j] + 1))
-                end
-                print(io, "│")
-            end
+            strs = _showval.(values(ta))
+            ts   = timestamp(ta)
         end
 
-        if length(pages) > 1 && p != pages[end]
-            print(io, "\n\n")
-        end
-    end  # for p ∈ pages
+        colwidth = maximum(
+            [textwidth.(string.(colnames(ta)))'; textwidth.(strs); fill(5, ncol)'],
+            dims = 1)
+
+        # paging
+        spacetime = textwidth(string(ts[1]))
+        pages = _showpages(dcol, spacetime, colwidth)
+
+        for p ∈ pages
+            # row label line
+            ## e.g. | Open  | High  | Low   | Close  |
+            print(io, "│", " "^(spacetime + 2))
+            for (name, w) in zip(colnames(ta)[p], colwidth[p])
+                print(io, "│ ", rpad(name, w + 1))
+            end
+            println(io, "│")
+            ## e.g. ├───────┼───────┼───────┼────────┤
+            print(io, "├", "─"^(spacetime + 2))
+            for w in colwidth[p]
+                print(io, "┼", "─"^(w + 2))
+            end
+            print(io, "┤")
+
+            # timestamp and values line
+            if nrow > (drow - res_row)
+                for i in tophalf
+                    println(io)
+                    print(io, "│ ", ts[i], " ")
+                    for j in p
+                        print(io, "│ ", rpad(strs[i, j], colwidth[j] + 1))
+                    end
+                    print(io, "│")
+                end
+
+                print(io, "\n   \u22EE")
+
+                for i in (length(bothalf) - 1):-1:0
+                    i = size(strs, 1) - i
+                    println(io)
+                    print(io, "│ ", ts[i], " ")
+                    for j in p
+                        print(io, "│ ", rpad(strs[i, j], colwidth[j] + 1))
+                    end
+                    print(io, "│")
+                end
+
+            else
+                for i in 1:nrow
+                    println(io)
+                    print(io, "│ ", ts[i], " ")
+                    for j in p
+                        print(io, "│ ", rpad(strs[i, j], colwidth[j] + 1))
+                    end
+                    print(io, "│")
+                end
+            end
+
+            if length(pages) > 1 && p != pages[end]
+                print(io, "\n\n")
+            end
+        end  # for p ∈ pages
     end # if !short
 end
 Base.show(io::IO, ta::TimeSeries.TimeArray) = print_time_array(io, ta, true)

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -300,8 +300,9 @@ function print_time_array(io::IO, ta::TimeArray{T}, short=false) where T
         end
     end  # for p ∈ pages
 end
-Base.show(io::IO, ta::TimeSeries.TimeArray) = print_time_array(io, ta, true)
-Base.show(io::IO, ::MIME"text/plain", ta::TimeArray) = print_time_array(io, ta, false)
+Base.show(io::IO, ta::TimeArray) = print_time_array(io, ta, true)
+Base.show(io::IO, ::MIME"text/plain", ta::TimeArray) =
+    print_time_array(io, ta, false)
 
 
 ###### getindex #################

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -430,11 +430,11 @@ end
 @testset "show methods don't throw errors" begin
     io = IOBuffer()
     let str = sprint(show, cl)
-        out = "500×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31\n"
+        out = "500×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31"
         @test str == out
     end
     show(io, "text/plain", cl)
-    let str = String(take!(io))    
+    let str = String(take!(io))
         out = """500×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31
 │            │ Close  │
 ├────────────┼────────┤
@@ -461,7 +461,7 @@ end
 
     # my edits above seem to work -- now need to do for the rest, JJS 2/22/19
     let str = sprint(show, ohlc)
-        out = "500×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2001-12-31\n"
+        out = "500×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2001-12-31"
         @test str == out
     end
     show(io, "text/plain", ohlc)
@@ -491,7 +491,7 @@ end
     end
 
     let str = sprint(show, AAPL)
-        out = "8336×12 TimeArray{Float64,2,Date,Array{Float64,2}} 1980-12-12 to 2013-12-31\n"
+        out = "8336×12 TimeArray{Float64,2,Date,Array{Float64,2}} 1980-12-12 to 2013-12-31"
         @test str == out
     end
     show(io, "text/plain", AAPL)
@@ -542,7 +542,7 @@ end
     end
 
     let str = sprint(show, ohlc[1:4])
-        out = "4×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2000-01-06\n"    
+        out = "4×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2000-01-06"
         @test str == out
     end
     show(io, "text/plain", ohlc[1:4])
@@ -576,7 +576,7 @@ end
     end
 
     let str = sprint(show, lag(cl[1:2], padding=true))
-        out = "2×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2000-01-04\n"
+        out = "2×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2000-01-04"
         @test str == out
     end
     show(io, "text/plain", lag(cl[1:2], padding=true))

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -428,7 +428,13 @@ end
 
 
 @testset "show methods don't throw errors" begin
+    io = IOBuffer()
     let str = sprint(show, cl)
+        out = "500×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31\n"
+        @test str == out
+    end
+    show(io, "text/plain", cl)
+    let str = String(take!(io))    
         out = """500×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2001-12-31
 │            │ Close  │
 ├────────────┼────────┤
@@ -453,7 +459,13 @@ end
         @test str == out
     end
 
+    # my edits above seem to work -- now need to do for the rest, JJS 2/22/19
     let str = sprint(show, ohlc)
+        out = "500×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2001-12-31\n"
+        @test str == out
+    end
+    show(io, "text/plain", ohlc)
+    let str = String(take!(io))
         out = """500×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2001-12-31
 │            │ Open   │ High   │ Low    │ Close  │
 ├────────────┼────────┼────────┼────────┼────────┤
@@ -479,6 +491,11 @@ end
     end
 
     let str = sprint(show, AAPL)
+        out = "8336×12 TimeArray{Float64,2,Date,Array{Float64,2}} 1980-12-12 to 2013-12-31\n"
+        @test str == out
+    end
+    show(io, "text/plain", AAPL)
+    let str = String(take!(io))
         out = """8336×12 TimeArray{Float64,2,Date,Array{Float64,2}} 1980-12-12 to 2013-12-31
 │            │ Open   │ High   │ Low    │ Close  │ Volume    │ Ex-Dividend │
 ├────────────┼────────┼────────┼────────┼────────┼───────────┼─────────────┤
@@ -525,6 +542,11 @@ end
     end
 
     let str = sprint(show, ohlc[1:4])
+        out = "4×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2000-01-06\n"    
+        @test str == out
+    end
+    show(io, "text/plain", ohlc[1:4])
+    let str = String(take!(io))
         out = """4×4 TimeArray{Float64,2,Date,Array{Float64,2}} 2000-01-03 to 2000-01-06
 │            │ Open   │ High   │ Low    │ Close  │
 ├────────────┼────────┼────────┼────────┼────────┤
@@ -535,15 +557,30 @@ end
         @test str == out
     end
 
+
     let str = sprint(show, ohlc[1:0])
         @test str == "0×4 TimeArray{Float64,2,Date,Array{Float64,2}}"
     end
+    show(io, "text/plain", ohlc[1:0])
+    let str = String(take!(io))
+        @test str == "0×4 TimeArray{Float64,2,Date,Array{Float64,2}}"
+    end
+
 
     let str = sprint(show, TimeArray(Date[], []))
         @test str == "0×1 TimeArray{Any,1,Date,Array{Any,1}}"
     end
+    show(io, "text/plain", TimeArray(Date[], []))
+    let str = String(take!(io))
+        @test str == "0×1 TimeArray{Any,1,Date,Array{Any,1}}"
+    end
 
     let str = sprint(show, lag(cl[1:2], padding=true))
+        out = "2×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2000-01-04\n"
+        @test str == out
+    end
+    show(io, "text/plain", lag(cl[1:2], padding=true))
+    let str = String(take!(io))
         out = """2×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-03 to 2000-01-04
 │            │ Close  │
 ├────────────┼────────┤


### PR DESCRIPTION
Now a one-line short version will be output (when no MIME type is specified). The previous long version will be output for ::MIME"text/plain", e.g., when printing in the REPL. The tests were also updated.

The motivation for this change comes from including timearray objects in structs and dicts. Printing of the parent object resulted in the full printing of the timearray instead of a summary statement. This PR enables the printing of just a summary statement in such a case.