### PR TITLE
 Support delimiter, header and format when writing time series

### DIFF
--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -14,13 +14,13 @@ function readtimearray(source; delim::Char = ',', meta = nothing,
     time = cfile[1:end, 1]
     if length(time[1]) < 11
         # assuming Date not DateTime
-        format == "" ?
-        tstamps = Date[Date(t) for t in time] :
-        tstamps = Date[Date(t, format) for t in time]
+        tstamps = isempty(format) ?
+            Date[Date(t) for t in time] :
+            Date[Date(t, format) for t in time]
     else
-        format == "" ?
-        tstamps = DateTime[DateTime(t) for t in time] :
-        tstamps = DateTime[DateTime(t, format) for t in time]
+        tstamps = isempty(format) ?
+            DateTime[DateTime(t) for t in time] :
+            DateTime[DateTime(t, format) for t in time]
     end
 
     vals   = insertNaN(cfile[1:end, 2:end])
@@ -39,12 +39,10 @@ function insertNaN(aa::Array{Any, N}) where {N}
     convert(Array{Float64, N}, aa)
 end
 
-function writetimearray(ta::TimeArray, fname::AbstractString; 
+function writetimearray(ta::TimeArray, fname::AbstractString;
                         delim::Char = ',', format::AbstractString = "",
                         header::Bool = true)
-
     open(fname, "w") do io
-
         if header
             strvals = join(colnames(ta), delim)
             write(io, string("Timestamp", delim, strvals, "\n"))
@@ -52,12 +50,10 @@ function writetimearray(ta::TimeArray, fname::AbstractString;
 
         for i in eachindex(timestamp(ta))
             strvals = replace(join(values(ta)[i, :], delim), "NaN" => "")
-            format == "" ?
-            strtstamp = string(timestamp(ta)[i]) :
-            strtstamp = Dates.format(timestamp(ta)[i], format)
+            strtstamp = isempty(format) ?
+                string(timestamp(ta)[i]) :
+                Dates.format(timestamp(ta)[i], format)
             write(io, string(strtstamp, delim, strvals, "\n"))
-        end  # for
-
+        end
     end
-
 end  # writetimearray

--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -39,16 +39,23 @@ function insertNaN(aa::Array{Any, N}) where {N}
     convert(Array{Float64, N}, aa)
 end
 
-function writetimearray(ta::TimeArray, fname::AbstractString)
+function writetimearray(ta::TimeArray, fname::AbstractString; 
+                        delim::Char = ',', format::AbstractString = "",
+                        header::Bool = true)
 
     open(fname, "w") do io
 
-        strvals = join(colnames(ta), ",")
-        write(io, string("Timestamp,", strvals, "\n"))
+        if header
+            strvals = join(colnames(ta), delim)
+            write(io, string("Timestamp", delim, strvals, "\n"))
+        end
 
         for i in eachindex(timestamp(ta))
-            strvals = replace(join(values(ta)[i, :], ","), "NaN" => "")
-            write(io, string(timestamp(ta)[i], ",", strvals, "\n"))
+            strvals = replace(join(values(ta)[i, :], delim), "NaN" => "")
+            format == "" ?
+            strtstamp = string(timestamp(ta)[i]) :
+            strtstamp = Dates.format(timestamp(ta)[i], format)
+            write(io, string(strtstamp, delim, strvals, "\n"))
         end  # for
 
     end

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -90,12 +90,12 @@ end
     uohlc    = uniformspace(ohlc)
     writetimearray(uohlc, filename)
     readback = readtimearray(filename)
+    rm(filename)
 
     @testset "writetimearray output can be round-tripped" begin
         @test colnames(uohlc)  == colnames(readback)
         @test timestamp(uohlc) == timestamp(readback)
         @test isequal(values(uohlc), values(readback))
-        rm(filename)
     end
 end
 

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -85,7 +85,7 @@ end
 end
 
 
-@testset "writetimearray method works" begin
+@testset "writetimearray method with default parameters works" begin
     filename = "$(randstring()).csv"
     uohlc    = uniformspace(ohlc)
     writetimearray(uohlc, filename)
@@ -99,5 +99,43 @@ end
     end
 end
 
+@testset "writetimearray method with a delimiter works" begin
+    filename = "$(randstring()).csv"
+    uohlc    = uniformspace(ohlc)
+    writetimearray(uohlc[1:5], filename, delim=';')
+    readback = readtimearray(filename, delim=';')
+    rm(filename)
+
+    @testset "writetimearray output can be round-tripped" begin
+        @test colnames(uohlc[1:5])  == colnames(readback)
+        @test timestamp(uohlc[1:5]) == timestamp(readback)
+        @test isequal(values(uohlc[1:5]), values(readback))
+    end
+end
+
+@testset "writetimearray method with no header works" begin
+    filename = "$(randstring()).csv"
+    uohlc    = uniformspace(ohlc)
+    writetimearray(uohlc[1:5], filename, header=false)
+    readback = readtimearray(filename, header=false)
+    rm(filename)
+
+    @testset "writetimearray output can be round-tripped" begin
+        @test timestamp(uohlc[1:5]) == timestamp(readback)
+        @test isequal(values(uohlc[1:5]), values(readback))
+    end
+end
+
+@testset "writetimearray method with a timestamp format works" begin
+    filename = "$(randstring()).csv"
+    uohlc    = uniformspace(ohlc)
+    writetimearray(uohlc[1:5], filename, format="yyyy/mm/dd")
+    readback = readtimearray(filename, format="yyyy/mm/dd")
+    rm(filename)
+
+    @testset "writetimearray output can be round-tripped" begin
+        @test timestamp(uohlc[1:5]) == timestamp(readback)
+    end
+end
 
 end  # @testset "readwrite"

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -87,8 +87,7 @@ end
 
 @testset "writetimearray method with default parameters works" begin
     mktemp() do filename, _io
-        filename = "$(randstring()).csv"
-        uohlc    = uniformspace(ohlc)
+        uohlc = uniformspace(ohlc)
         writetimearray(uohlc, filename)
         readback = readtimearray(filename)
 
@@ -100,8 +99,7 @@ end
 
 @testset "writetimearray method with a delimiter works" begin
     mktemp() do filename, _io
-        filename = "$(randstring()).csv"
-        uohlc    = uniformspace(ohlc)
+        uohlc = uniformspace(ohlc)
         writetimearray(uohlc[1:5], filename, delim=';')
         readback = readtimearray(filename, delim=';')
 
@@ -113,7 +111,7 @@ end
 
 @testset "writetimearray method with no header works" begin
     mktemp() do filename, _io
-        uohlc    = uniformspace(ohlc)
+        uohlc = uniformspace(ohlc)
         writetimearray(uohlc[1:5], filename, header=false)
         readback = readtimearray(filename, header=false)
 
@@ -124,7 +122,7 @@ end
 
 @testset "writetimearray method with a timestamp format works" begin
     mktemp() do filename, _io
-        uohlc    = uniformspace(ohlc)
+        uohlc = uniformspace(ohlc)
         writetimearray(uohlc[1:5], filename, format="yyyy/mm/dd")
         readback = readtimearray(filename, format="yyyy/mm/dd")
 

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -86,13 +86,12 @@ end
 
 
 @testset "writetimearray method with default parameters works" begin
-    filename = "$(randstring()).csv"
-    uohlc    = uniformspace(ohlc)
-    writetimearray(uohlc, filename)
-    readback = readtimearray(filename)
-    rm(filename)
+    mktemp() do filename, _io
+        filename = "$(randstring()).csv"
+        uohlc    = uniformspace(ohlc)
+        writetimearray(uohlc, filename)
+        readback = readtimearray(filename)
 
-    @testset "writetimearray output can be round-tripped" begin
         @test colnames(uohlc)  == colnames(readback)
         @test timestamp(uohlc) == timestamp(readback)
         @test isequal(values(uohlc), values(readback))
@@ -100,13 +99,12 @@ end
 end
 
 @testset "writetimearray method with a delimiter works" begin
-    filename = "$(randstring()).csv"
-    uohlc    = uniformspace(ohlc)
-    writetimearray(uohlc[1:5], filename, delim=';')
-    readback = readtimearray(filename, delim=';')
-    rm(filename)
+    mktemp() do filename, _io
+        filename = "$(randstring()).csv"
+        uohlc    = uniformspace(ohlc)
+        writetimearray(uohlc[1:5], filename, delim=';')
+        readback = readtimearray(filename, delim=';')
 
-    @testset "writetimearray output can be round-tripped" begin
         @test colnames(uohlc[1:5])  == colnames(readback)
         @test timestamp(uohlc[1:5]) == timestamp(readback)
         @test isequal(values(uohlc[1:5]), values(readback))
@@ -114,26 +112,22 @@ end
 end
 
 @testset "writetimearray method with no header works" begin
-    filename = "$(randstring()).csv"
-    uohlc    = uniformspace(ohlc)
-    writetimearray(uohlc[1:5], filename, header=false)
-    readback = readtimearray(filename, header=false)
-    rm(filename)
+    mktemp() do filename, _io
+        uohlc    = uniformspace(ohlc)
+        writetimearray(uohlc[1:5], filename, header=false)
+        readback = readtimearray(filename, header=false)
 
-    @testset "writetimearray output can be round-tripped" begin
         @test timestamp(uohlc[1:5]) == timestamp(readback)
         @test isequal(values(uohlc[1:5]), values(readback))
     end
 end
 
 @testset "writetimearray method with a timestamp format works" begin
-    filename = "$(randstring()).csv"
-    uohlc    = uniformspace(ohlc)
-    writetimearray(uohlc[1:5], filename, format="yyyy/mm/dd")
-    readback = readtimearray(filename, format="yyyy/mm/dd")
-    rm(filename)
+    mktemp() do filename, _io
+        uohlc    = uniformspace(ohlc)
+        writetimearray(uohlc[1:5], filename, format="yyyy/mm/dd")
+        readback = readtimearray(filename, format="yyyy/mm/dd")
 
-    @testset "writetimearray output can be round-tripped" begin
         @test timestamp(uohlc[1:5]) == timestamp(readback)
     end
 end


### PR DESCRIPTION
To make writetimearray() symmetric with readtimearray().