### PR TITLE
Plotting: labels as strings

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -7,7 +7,7 @@
     #    ta, ohlc = extract_ohlc(ta)
     #    collect(zip(ohlc)) # But there are currently issues with that
     else
-        labels --> reshape(colnames(ta),1,length(colnames(ta)))
+        labels --> reshape(String.(colnames(ta)),1,length(colnames(ta)))
         seriestype := st
         timestamp(ta), values(ta)
     end


### PR DESCRIPTION
This is a workaround for a bug in Plots.pgfplots() which prevents labels::Symbol to be shown.

see JuliaPlots/Plots.jl#2020