### PR TITLE
apply: improve performance of `moving`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+### 0.16.0
+
+* Improve performance of `moving` function. (TBD)
+
+
 ### 0.15.0
 
 * New `TimeArray` constructor for creating a `TimeArray` from existing `TimeArray`.

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -185,12 +185,12 @@ using TimeSeries
 
         @testset "moving with do syntax" begin
             moving(cl, 10) do x
-                @test isa(x, Array{Float64, 1})
+                @test isa(x, AbstractArray{Float64,1})
                 x[1]
             end
 
             moving(ohlc, 10) do x
-                @test isa(x, Array{Float64, 1})
+                @test isa(x, AbstractArray{Float64,1})
                 x[1]
             end
         end


### PR DESCRIPTION
* introduce `SubArray` to remove allocations.

* Case of single column `TimeArray`:

  Before
  ```julia
  julia> @benchmark moving(mean, cl, 20)
  BenchmarkTools.Trial:
    memory estimate:  125.06 KiB
    allocs estimate:  489
    --------------
    minimum time:     34.383 μs (0.00% GC)
    median time:      44.607 μs (0.00% GC)
    mean time:        58.768 μs (14.77% GC)
    maximum time:     46.406 ms (99.84% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```

  After
  ```julia
  julia> @benchmark moving(mean, cl, 20)
  BenchmarkTools.Trial:
    memory estimate:  31.05 KiB
    allocs estimate:  491
    --------------
    minimum time:     12.639 μs (0.00% GC)
    median time:      13.740 μs (0.00% GC)
    mean time:        24.643 μs (37.05% GC)
    maximum time:     57.679 ms (99.95% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```

* Case of multiple column `TimeArray`:

  Before:
  ```julia
  julia> @benchmark moving(mean, ohlc, 20)
  BenchmarkTools.Trial:
    memory estimate:  485.77 KiB
    allocs estimate:  1932
    --------------
    minimum time:     164.404 μs (0.00% GC)
    median time:      170.992 μs (0.00% GC)
    mean time:        211.102 μs (6.68% GC)
    maximum time:     45.746 ms (99.58% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```

  After:
  ```julia
  julia> @benchmark moving(mean, ohlc, 20)
  BenchmarkTools.Trial:
    memory estimate:  140.00 KiB
    allocs estimate:  1934
    --------------
    minimum time:     50.754 μs (0.00% GC)
    median time:      58.020 μs (0.00% GC)
    mean time:        75.084 μs (18.28% GC)
    maximum time:     70.064 ms (99.82% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```