### PR TITLE
apply: `moving` with multi-column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 * Improve performance of `moving` function. (TBD)
 
+* `moving` supports multi-column as input for user-defined function. (#415)
+
+  ```julia
+  moving(ohlc, 10, dims = 2, colnames = [:A, ...]) do
+    # given ohlc is a 500x4 TimeArray,
+    # size(A) is (10, 4)
+    ...
+  end
+  ```
+
 
 ### 0.15.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
   ```julia
   moving(ohlc, 10, dims = 2, colnames = [:A, ...]) do
-    # given ohlc is a 500x4 TimeArray,
+    # given that `ohlc` is a 500x4 `TimeArray`,
     # size(A) is (10, 4)
     ...
   end

--- a/docs/src/apply.md
+++ b/docs/src/apply.md
@@ -112,15 +112,6 @@ percentchange(cl, :log)
 
 ## `moving`
 
-Function signature:
-
-```julia
-moving(f, ta::TimeArray, window; padding=false)
-moving(ta, window; padding=false) do x
-  ...
-end
-```
-
 Often when working with time series, you want to take a sliding window
 view of the data and perform a calculation on it. The simplest example
 of this is the moving average. For a 10-period moving average, you take
@@ -142,6 +133,10 @@ moving(mean, cl, 10)
 As mentioned previously, we lose the first nine observations to the
 consuming nature of this operation. They are not **missing** per se,
 they simply do not exist.
+
+```@docs
+moving
+```
 
 ## `upto`
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -108,7 +108,7 @@ function moving(f, ta::TimeArray{T,2}, window::Integer;
     else # case of dims = 2
         vals = mapreduce(i -> f(view(A, i-window+1:i, :)), vcat, window:size(A, 1))
         if size(vals, 2) != length(colnames)
-            throw(ArgumentError(
+            throw(DimensionMismatch(
                 "the output dims should match the lenght of columns, " *
                 "please set the keyword argument `colnames` properly."
             ))

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -81,6 +81,18 @@ end  # percentchange
 ###### moving ###################
 
 # Note: please do not involve any side effects in function `f`
+"""
+    moving(f, ta::TimeArray{T,1}, w::Integer; padding = false)
+
+Apply user-defined function `f` to a 1D `TimeArray` with window size `w`.
+
+## Example
+To calculate the simple moving average of a time series:
+
+```julia
+moving(mean, ta, 10)
+```
+"""
 function moving(f, ta::TimeArray{T,1}, window::Integer;
                 padding::Bool = false) where {T}
     ts   = padding ? timestamp(ta) : @view(timestamp(ta)[window:end])
@@ -90,6 +102,21 @@ function moving(f, ta::TimeArray{T,1}, window::Integer;
     TimeArray(ta; timestamp = ts, values = vals)
 end
 
+
+"""
+    moving(f, ta::TimeArray{T,2}, w::Integer; padding = false, dims = 1, colnames = [...])
+
+## Example
+In case of `dims = 2`, the user-defined function `f` will get a 2D `Array` as input.
+
+```julia
+moving(ohlc, 10, dims = 2, colnames = [:A, ...]) do
+    # given that `ohlc` is a 500x4 `TimeArray`,
+    # size(A) is (10, 4)
+    ...
+end
+```
+"""
 function moving(f, ta::TimeArray{T,2}, window::Integer;
                 padding::Bool = false, dims::Integer = 1,
                 colnames::AbstractVector{Symbol} = _colnames(ta)) where {T}

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -106,7 +106,7 @@ function moving(f, ta::TimeArray{T,2}, window::Integer;
             vals[i, j] = f(@view(A[i:i+(window-1), j]))
         end
     else # case of dims = 2
-        vals = mapreduce(i -> f(view(A, i, :)), vcat, window:size(A, 1))
+        vals = mapreduce(i -> f(view(A, i-window+1:i, :)), vcat, window:size(A, 1))
         if size(vals, 2) != length(colnames)
             throw(ArgumentError(
                 "the output dims should match the lenght of columns, " *

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -115,7 +115,7 @@ function moving(f, ta::TimeArray{T,2}, window::Integer;
         end
     end
 
-    padding && (vals = [fill(NaN, size(A[1:(window-1), :])); vals])
+    padding && (vals = [fill(NaN, (window-1), size(vals, 2)); vals])
     TimeArray(ta; timestamp = ts, values = vals, colnames = colnames)
 end
 

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -213,6 +213,11 @@ using TimeSeries
                 mean(A, dims = 1)
             end
             @test length(ta) == length(ohlc)
+            @test all(isnan.(values(ta[1:9])))
+
+            # exceptions
+            @test_throws ArgumentError moving(mean, ohlc, 24, dims = 42)
+            @test_throws DimensionMismatch moving(mean, ohlc, 24, dims = 2)
         end
     end
 

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -207,6 +207,12 @@ using TimeSeries
             ans = moving(mean, ohlc, 10)
             @test values(ta)       ≈ values(ans)
             @test timestamp(ta)   == timestamp(ta)
+
+            # with padding
+            ta = moving(ohlc, 10, dims = 2, padding = true) do A
+                mean(A, dims = 1)
+            end
+            @test length(ta) == length(ohlc)
         end
     end
 

--- a/test/apply.jl
+++ b/test/apply.jl
@@ -194,6 +194,20 @@ using TimeSeries
                 x[1]
             end
         end
+
+        @testset "moving with multi-column" begin
+            ta = moving(mean, ohlc, 1, dims = 2, colnames = [:mean])
+            ans = mean(ohlc, dims = 2)
+            @test all(values(ta) .== values(ans))
+            @test timestamp(ta)   == timestamp(ta)
+
+            ta = moving(ohlc, 10, dims = 2) do A
+                mean(A, dims = 1)
+            end
+            ans = moving(mean, ohlc, 10)
+            @test values(ta)       ≈ values(ans)
+            @test timestamp(ta)   == timestamp(ta)
+        end
     end
 
     @testset "upto method accumulates" begin


### PR DESCRIPTION
Ref: #401 

TODO
- [x] docstring
- [x] doc page
- [x] test cases
- [x] News

e.g.
```julia
julia> moving(ohlc, 5, dims = 2, colnames = [:μ]) do A
         mean(A, dims = 1)
       end
496×1 TimeArray{Float64,1,Date,Array{Float64,1}} 2000-01-07 to 2001-12-31
│            │ μ        │
├────────────┼──────────┤
│ 2000-01-07 │ 98.125   │
│ 2000-01-10 │ 99.1875  │
│ 2000-01-11 │ 94.6425  │
│ 2000-01-12 │ 91.0475  │
│ 2000-01-13 │ 95.62    │
│ 2000-01-14 │ 100.5175 │
│ 2000-01-18 │ 102.845  │
│ 2000-01-19 │ 106.0775 │
│ 2000-01-20 │ 116.0    │
│ 2000-01-21 │ 112.5    │
│ 2000-01-24 │ 108.14   │
│ 2000-01-25 │ 108.1875 │
│ 2000-01-26 │ 111.0325 │
│ 2000-01-27 │ 109.7025 │

```