### PR TITLE
timearray: `getindex(ta)` throws BoundsError

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,14 @@
 
 * Fix issues of `TimeArray` column names copying. (#418)
 
+* `ta[]` throws `BoundsError` now. (#420)
+
+  ```julia
+  julia> cl[]
+  ERROR: BoundsError: attempt to access TimeArray{Float64,1,Date,Array{Float64,1}}
+    at index []
+  ```
+
 
 ### 0.15.0
 

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -312,6 +312,11 @@ Base.show(io::IO, ::MIME"text/plain", ta::TimeArray) =
 
 ###### getindex #################
 
+# the getindex function should return a new TimeArray, and copy data from
+# the source, includes `timestamp`, `values` and `colnames`.
+
+getindex(ta::TimeArray) = throw(BoundsError(typeof(ta), []))
+
 # single row
 getindex(ta::TimeArray, n::Integer) =
     # avoid conversion to column vector

--- a/test/timearray.jl
+++ b/test/timearray.jl
@@ -239,6 +239,9 @@ end
         @test colnames(ta)  == [:Open, :High, :Low, :Close]
         @test meta(ta)      == "AAPL"
     end
+
+    @test_throws BoundsError cl[]
+    @test_throws BoundsError ohlc[]
 end
 
 


### PR DESCRIPTION
close #420

```julia
julia> cl[]
ERROR: BoundsError: attempt to access TimeArray{Float64,1,Date,Array{Float64,1}}
  at index []
```