### PR TITLE
timearray: fix `inbounds` handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 * Fix issues of `TimeArray` column names copying. (#418)
 
+* Fix `@inbounds` handling for `TimeArray`. (#425)
+
 * `timearray[]` throws `BoundsError` now. (#420)
 
   ```julia

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -1,5 +1,7 @@
 ###### type definition ##########
 
+using Base: @propagate_inbounds
+
 import Base: convert, copy, length, show, getindex, iterate,
              lastindex, size, eachindex, ==, isequal, hash, ndims,
              getproperty, propertynames, values
@@ -318,43 +320,43 @@ Base.show(io::IO, ::MIME"text/plain", ta::TimeArray) =
 getindex(ta::TimeArray) = throw(BoundsError(typeof(ta), []))
 
 # single row
-getindex(ta::TimeArray, n::Integer) =
+@propagate_inbounds getindex(ta::TimeArray, n::Integer) =
     # avoid conversion to column vector
     TimeArray(timestamp(ta)[n], values(ta)[n:n, :], colnames(ta), meta(ta))
 
 # single row 1d
-getindex(ta::TimeArray{T,1}, n::Integer) where {T} =
+@propagate_inbounds getindex(ta::TimeArray{T,1}, n::Integer) where {T} =
     TimeArray(timestamp(ta)[n], values(ta)[[n]], colnames(ta), meta(ta))
 
 # range of rows
-getindex(ta::TimeArray, r::UnitRange{<:Integer}) =
+@propagate_inbounds getindex(ta::TimeArray, r::UnitRange{<:Integer}) =
     TimeArray(timestamp(ta)[r], values(ta)[r, :], colnames(ta), meta(ta))
 
 # range of 1d rows
-getindex(ta::TimeArray{T,1}, r::UnitRange{<:Integer}) where T =
+@propagate_inbounds getindex(ta::TimeArray{T,1}, r::UnitRange{<:Integer}) where T =
     TimeArray(timestamp(ta)[r], values(ta)[r], colnames(ta), meta(ta))
 
 # array of rows
-getindex(ta::TimeArray, a::AbstractVector{<:Integer}) =
+@propagate_inbounds getindex(ta::TimeArray, a::AbstractVector{<:Integer}) =
     TimeArray(timestamp(ta)[a], values(ta)[a, :], colnames(ta), meta(ta))
 
 # array of 1d rows
-getindex(ta::TimeArray{T,1}, a::AbstractVector{<:Integer}) where T =
+@propagate_inbounds getindex(ta::TimeArray{T,1}, a::AbstractVector{<:Integer}) where T =
     TimeArray(timestamp(ta)[a], values(ta)[a], colnames(ta), meta(ta))
 
 # single column by name
-function getindex(ta::TimeArray, s::Symbol)
+@propagate_inbounds function getindex(ta::TimeArray, s::Symbol)
     n = findcol(ta, s)
     TimeArray(timestamp(ta), values(ta)[:, n], Symbol[s], meta(ta), unchecked = true)
 end
 
 # array of columns by name
-getindex(ta::TimeArray, ss::Symbol...) = getindex(ta, collect(ss))
-getindex(ta::TimeArray, ss::Vector{Symbol}) =
+@propagate_inbounds getindex(ta::TimeArray, ss::Symbol...) = getindex(ta, collect(ss))
+@propagate_inbounds getindex(ta::TimeArray, ss::Vector{Symbol}) =
     TimeArray(ta; values = values(ta)[:, map(s -> findcol(ta, s), ss)], colnames = ss)
 
 # ta[rows, cols]
-getindex(ta::TimeArray,
+@propagate_inbounds getindex(ta::TimeArray,
          rows::Union{AbstractVector{<:Integer},Colon},
          cols::AbstractVector{Symbol}) =
     TimeArray(
@@ -365,34 +367,34 @@ getindex(ta::TimeArray,
         unchecked = true)
 
 # ta[n, cols]
-getindex(ta::TimeArray, n::Integer, cols) =
+@propagate_inbounds getindex(ta::TimeArray, n::Integer, cols) =
     getindex(ta, [n], cols)
 
 # ta[rows, col]
-getindex(ta::TimeArray, rows, col::Symbol) =
+@propagate_inbounds getindex(ta::TimeArray, rows, col::Symbol) =
     getindex(ta, rows, [col])
 
 # ta[n, col]
-getindex(ta::TimeArray, n::Integer, col::Symbol) =
+@propagate_inbounds getindex(ta::TimeArray, n::Integer, col::Symbol) =
     getindex(ta, [n], [col])
 
 # single date
-function getindex(ta::TimeArray{T,N,D}, d::D) where {T,N,D}
+@propagate_inbounds function getindex(ta::TimeArray{T,N,D}, d::D) where {T,N,D}
     idxs = searchsorted(timestamp(ta), d)
     length(idxs) == 1 ? ta[idxs[1]] : nothing
 end
 
 # multiple dates
-function getindex(ta::TimeArray{T,N,D}, dates::Vector{D}) where {T,N,D}
+@propagate_inbounds function getindex(ta::TimeArray{T,N,D}, dates::Vector{D}) where {T,N,D}
     dates = sort(dates)
     idxs, _ = overlap(timestamp(ta), dates)
     ta[idxs]
 end
 
 # StepRange{Date,...}
-getindex(ta::TimeArray{T,N,D}, r::StepRange{D}) where {T,N,D} = ta[collect(r)]
+@propagate_inbounds getindex(ta::TimeArray{T,N,D}, r::StepRange{D}) where {T,N,D} = ta[collect(r)]
 
-getindex(ta::TimeArray, k::TimeArray{Bool,1}) = ta[findwhen(k)]
+@propagate_inbounds getindex(ta::TimeArray, k::TimeArray{Bool,1}) = ta[findwhen(k)]
 
 # day of week
 # getindex{T,N}(ta::TimeArray{T,N}, d::DAYOFWEEK) = ta[dayofweek(timestamp(ta)) .== d]


### PR DESCRIPTION
E.g.

```julia
julia> f(ta) = @inbounds ta[1000]
f (generic function with 1 method)

julia> f(cl)
1×1 TimeArray{Float64,1,Date,Array{Float64,1}} 40636496360509-30141738682531949-3689348814741910343 to 40636496360509-30141738682531949-3689348814741910343
│                                                      │ Close │
├──────────────────────────────────────────────────────┼───────┤
│ 40636496360509-30141738682531949-3689348814741910343 │ 0.0   │
```