### PR TITLE
TimeArray: add a new kw args for Tables constructor

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -63,8 +63,8 @@ Tables.schema(i::TableIter{T,S}) where {T,S} = Tables.Schema(S, coltypes(data(i)
 
 coltypes(x::AbstractTimeSeries{T,N,D}) where {T,N,D} = (D, (T for _ ∈ 1:size(x, 2))...)
 
-function TimeSeries.TimeArray(x; timestamp::Symbol)
-    Tables.istable(x) || throw(ArgumentError("TimeArray requires a table input"))
+function TimeSeries.TimeArray(x; timestamp::Symbol, timeparser::Base.Callable = identity)
+    Tables.istable(x) || throw(ArgumentError("TimeArray requires a table as input"))
 
     sch = Tables.schema(x)
     names = sch.names
@@ -72,8 +72,8 @@ function TimeSeries.TimeArray(x; timestamp::Symbol)
     names′ = filter(!isequal(timestamp), collect(sch.names))
 
     cols = Tables.columns(x)
-    val = mapreduce(n -> collect(getproperty(cols, n)), hcat, names′)
-    TimeArray(collect(getproperty(cols, timestamp)), val, names′, x)
+    val = mapreduce(n -> collect(Tables.getcolumn(cols, n)), hcat, names′)
+    TimeArray(map(timeparser, Tables.getcolumn(cols, timestamp)), val, names′, x)
 end
 
 end  # TablesIntegration

--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -16,7 +16,7 @@ abstract type AbstractTimeSeries{T,N,D} end
     TimeArray(timestamp, values[, colnames, meta = nothing])
     TimeArray(ta::TimeArray; timestamp, values, colnames, meta)
     TimeArray(data::NamedTuple, timestamp = :datetime, meta)
-    TimeArray(table; timestamp::Symbol)
+    TimeArray(table; timestamp::Symbol, timeparser::Callable = identity)
 
 The second constructor will yields a new TimeArray with the new given fields.
 Note that the unchanged fields will be shared, there aren't any copy for the
@@ -39,6 +39,9 @@ The third constructor builds a `TimeArray` from a `NamedTuple`.
   the column of `values`.
 
 - `meta::Any`: a user-defined metadata.
+
+- `timeparser::Callable`: a mapping function for converting the source time index.
+  For instance, `Dates.unix2datetime` is a common case.
 
 # Examples
 


### PR DESCRIPTION
- `TimeArray(table; ..., timeparser::Callable)`

e.g.
```julia
using Dates
TimeArray(CSV.File("..."), timestamp = :date, timeparser = Date ∘ unix2datetime)
```

close #442