### PR TITLE
findall: support custom function as argument

### DIFF
--- a/docs/src/split.md
+++ b/docs/src/split.md
@@ -84,6 +84,12 @@ typeof(red)
 ohlc[red]
 ```
 
+The following example won't create a temporary `Bool` vector, and gains better
+performance.
+```@repl
+findall(>(100), cl*)
+```
+
 ## Splitting by head and tail
 
 ### `head`

--- a/docs/src/split.md
+++ b/docs/src/split.md
@@ -87,7 +87,7 @@ ohlc[red]
 The following example won't create a temporary `Bool` vector, and gains better
 performance.
 ```@repl
-findall(>(100), cl*)
+findall(>(100), cl)
 ```
 
 ## Splitting by head and tail

--- a/docs/src/split.md
+++ b/docs/src/split.md
@@ -86,7 +86,13 @@ ohlc[red]
 
 The following example won't create a temporary `Bool` vector, and gains better
 performance.
-```@repl
+
+```@setup findall
+using TimeSeries
+using MarketData
+```
+
+```@repl findall
 findall(>(100), cl)
 ```
 

--- a/src/split.jl
+++ b/src/split.jl
@@ -22,6 +22,9 @@ to(ta::TimeArray{T, N, D}, d::D) where {T, N, D} =
 ###### findall ##################
 
 Base.findall(ta::TimeArray{Bool,1}) = findall(values(ta))
+Base.findall(f::Function, ta::TimeArray{T,1}) where {T} = findall(f, values(ta))
+Base.findall(f::Function, ta::TimeArray{T,2}) where {T} =
+    collect(i for (i, x) ∈ enumerate(eachrow(values(ta))) if f(x))
 
 ###### findwhen #################
 

--- a/src/split.jl
+++ b/src/split.jl
@@ -23,8 +23,10 @@ to(ta::TimeArray{T, N, D}, d::D) where {T, N, D} =
 
 Base.findall(ta::TimeArray{Bool,1}) = findall(values(ta))
 Base.findall(f::Function, ta::TimeArray{T,1}) where {T} = findall(f, values(ta))
-Base.findall(f::Function, ta::TimeArray{T,2}) where {T} =
-    collect(i for (i, x) ∈ enumerate(eachrow(values(ta))) if f(x))
+function Base.findall(f::Function, ta::TimeArray{T,2}) where {T}
+    A = values(ta)
+    collect(i for i in axes(A, 1) if f(view(A, i, :)))
+end
 
 ###### findwhen #################
 

--- a/test/split.jl
+++ b/test/split.jl
@@ -21,7 +21,7 @@ using TimeSeries
     end
 
     @testset "findall(f::Function, ta)" begin
-        @test findall(cl .> 100) == findall(>(100), cl)
+        @test findall(cl .> 100) == findall(x -> x > 100, cl)
         @test findall(cl .> 100) == findall(x -> x[4] > 100, ohlc)
     end
 end

--- a/test/split.jl
+++ b/test/split.jl
@@ -19,6 +19,11 @@ using TimeSeries
        @test findwhen(cl .> op)[2]      == Date(2000, 1, 5)
        @test length(findwhen(cl .> op)) == 244
     end
+
+    @testset "findall(f::Function, ta)" begin
+        @test findall(cl .> 100) == findall(>(100), cl)
+        @test findall(cl .> 100) == findall(x -> x[4] > 100, ohlc)
+    end
 end
 
 


### PR DESCRIPTION
```julia
julia> @benchmark findall($cl .> 100)
BenchmarkTools.Trial:
  memory estimate:  10.53 KiB
  allocs estimate:  28
  --------------
  minimum time:     6.108 μs (0.00% GC)
  median time:      7.105 μs (0.00% GC)
  mean time:        8.535 μs (9.45% GC)
  maximum time:     2.347 ms (98.30% GC)
  --------------
  samples:          10000
  evals/sample:     5

julia> @benchmark findall(>(100), $cl)
BenchmarkTools.Trial:
  memory estimate:  2.28 KiB
  allocs estimate:  8
  --------------
  minimum time:     2.064 μs (0.00% GC)
  median time:      2.974 μs (0.00% GC)
  mean time:        3.067 μs (2.51% GC)
  maximum time:     201.347 μs (97.47% GC)
  --------------
  samples:          10000
  evals/sample:     9
```

Ref https://github.com/JuliaStats/TimeSeries.jl/issues/456#issuecomment-800083464