### PR TITLE
combine: fix `collapse` period calculation for Dates accessors methods

### DIFF
--- a/docs/src/combine.md
+++ b/docs/src/combine.md
@@ -24,7 +24,7 @@ merge should then be 8,335 rows:
 ```@repl merge
 using TimeSeries
 using MarketData
-AppleCat = merge(AAPL,CAT);
+AppleCat = merge(AAPL, CAT);
 length(AppleCat)
 ```
 
@@ -70,19 +70,22 @@ the `last` value known and have that represented with the corresponding
 timestamp. A non-exhaustive list of valid time methods is presented
 below.
 
-| Dates method | Time length |
-|--------------|-------------|
-| `day`        | daily       |
-| `week`       | weekly      |
-| `month`      | monthly     |
-| `year`       | yearly      |
+| `Dates` method | Time length                   |
+|----------------|-------------------------------|
+| `day`          | daily                         |
+| `week`         | weekly, starting from Monday. |
+| `month`        | monthly                       |
+| `year`         | yearly                        |
+| `hour`         | hourly                        |
+| `minute`       | minutely                      |
+| `second`       | secondly                      |
 
 Showing this code in REPL:
 
 ```@repl collapse
 using TimeSeries
 using MarketData
-collapse(cl,month,last)
+collapse(cl, month, last)
 ```
 
 We can also supply the function that chooses the timestamp and the

--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -10,6 +10,8 @@ using RecipesBase
 using Reexport
 using Tables
 
+import Dates: quarter
+
 export TimeArray, AbstractTimeSeries,
        when, from, to, findwhen, timestamp, values, colnames, meta, head, tail,
        lag, lead, diff, percentchange, moving, upto,

--- a/src/TimeSeries.jl
+++ b/src/TimeSeries.jl
@@ -10,8 +10,6 @@ using RecipesBase
 using Reexport
 using Tables
 
-import Dates: quarter
-
 export TimeArray, AbstractTimeSeries,
        when, from, to, findwhen, timestamp, values, colnames, meta, head, tail,
        lag, lead, diff, percentchange, moving, upto,

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -122,8 +122,8 @@ for (F, T, P) ∈ ((:quarter,     :TimeType,               :Quarter),
     @eval let
         global collapse
         wrapper(x::$T) = floor(x, $P(1))
-        collapse(ta::TimeArray, ::typeof($F), timestamp::Function; kw...) =
-            collapse(ta, wrapper, timestamp; kw...)
+        collapse(ta::TimeArray, ::typeof($F), f::Function, g::Function = f; kw...) =
+            collapse(ta, wrapper, f, g; kw...)
     end
 end
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -101,6 +101,28 @@ hcat(x::TimeArray, y::TimeArray, zs::Vararg{TimeArray}) =
 
 # collapse ######################
 
+# accessors functions
+# https://github.com/JuliaLang/julia/blob/b617e8d3a77e49cd5625ca663af88e40f7796f15/stdlib/Dates/src/accessors.jl#L50
+
+# `year` doesn't need this wrapper
+for (F, T, P) ∈ ((:quarter,     :TimeType,               :Quarter),
+                 (:month,       :TimeType,               :Month),
+                 (:week,        :TimeType,               :Week),
+                 (:day,         :TimeType,               :Day),
+                 (:hour,        :(Union{DateTime,Time}), :Hour),
+                 (:minute,      :(Union{DateTime,Time}), :Minute),
+                 (:second,      :(Union{DateTime,Time}), :Second),
+                 (:millisecond, :(Union{DateTime,Time}), :Millisecond),
+                 (:microsecond, :Time,                   :Microsecond),
+                 (:nanosecond,  :Time,                   :Nanosecond))
+    @eval let
+        global collapse
+        wrapper(x::$T) = floor(x, $P(1))
+        collapse(ta::TimeArray, ::typeof($F), timestamp::Function; kw...) =
+            collapse(ta, wrapper, timestamp; kw...)
+    end
+end
+
 function collapse(ta::TimeArray{T,N,D}, period::Function, timestamp::Function,
                   value::Function = timestamp) where {T,N,D}
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -115,6 +115,10 @@ for (F, T, P) ∈ ((:quarter,     :TimeType,               :Quarter),
                  (:millisecond, :(Union{DateTime,Time}), :Millisecond),
                  (:microsecond, :Time,                   :Microsecond),
                  (:nanosecond,  :Time,                   :Nanosecond))
+    if F === :quarter
+        (VERSION < v"1.6") && continue
+        F = :(Dates.quarter)
+    end
     @eval let
         global collapse
         wrapper(x::$T) = floor(x, $P(1))

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -32,6 +32,92 @@ end
 
         @test values(collapse(ohlc, month, first))[2, :] == [104.0, 105.0, 100.0, 100.25]
         @test timestamp(collapse(ohlc, month, first))[2] == Date(2000,2,1)
+
+        # https://github.com/JuliaStats/TimeSeries.jl/issues/498
+        let  # quarter
+            ts = [
+                Date(2018, 1, 2),
+                Date(2018, 1, 3),
+                Date(2019, 1, 5),
+                Date(2019, 2, 6),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, Dates.quarter, last)
+            @test values(ta′)    == [2, 4]
+            @test timestamp(ta′) == ts[[2, 4]]
+        end
+        let  # week
+            ts = [
+                Date(2018, 1, 2),
+                Date(2018, 1, 3),
+                Date(2019, 1, 5),
+                Date(2019, 2, 6),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, week, last)
+            @test values(ta′)    == [2, 3, 4]
+            @test timestamp(ta′) == ts[[2, 3, 4]]
+        end
+        let  # month
+            ts = [
+                Date(2018, 1, 2),
+                Date(2018, 1, 3),
+                Date(2019, 1, 10),
+                Date(2019, 2, 5),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, month, last)
+            @test values(ta′)    == [2, 3, 4]
+            @test timestamp(ta′) == ts[[2, 3, 4]]
+        end
+        let  # day
+            ts = [
+                DateTime(2018, 1, 2, 10),
+                DateTime(2018, 1, 2, 12),
+                DateTime(2018, 2, 2, 12),
+                DateTime(2018, 2, 2, 14),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, day, last)
+            @test values(ta′)    == [2, 4]
+            @test timestamp(ta′) == ts[[2, 4]]
+        end
+        let  # hour
+            ts = [
+                DateTime(2018, 1, 2, 10, 0),
+                DateTime(2018, 1, 2, 12, 0),
+                DateTime(2018, 2, 2, 12, 0),
+                DateTime(2018, 2, 2, 12, 30),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, hour, last)
+            @test values(ta′)    == [1, 2, 4]
+            @test timestamp(ta′) == ts[[1, 2, 4]]
+        end
+        let  # minute
+            ts = [
+                DateTime(2018, 1, 2, 12, 0),
+                DateTime(2018, 1, 2, 12, 0, 30),
+                DateTime(2018, 1, 2, 13, 0),
+                DateTime(2018, 1, 2, 13, 0),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, minute, last)
+            @test values(ta′)    == [2, 4]
+            @test timestamp(ta′) == ts[[2, 4]]
+        end
+        let  # second
+            ts = [
+                DateTime(2018, 1, 2, 12, 0, 0),
+                DateTime(2018, 1, 2, 12, 0, 0, 30),
+                DateTime(2018, 1, 2, 13, 0, 0),
+                DateTime(2018, 1, 2, 13, 0, 0, 30),
+            ]
+            ta = TimeArray(ts, 1:length(ts))
+            ta′ = collapse(ta, second, last)
+            @test values(ta′)    == [2, 4]
+            @test timestamp(ta′) == ts[[2, 4]]
+        end
     end
 
     # https://github.com/JuliaStats/TimeSeries.jl/pull/397

--- a/test/combine.jl
+++ b/test/combine.jl
@@ -34,17 +34,19 @@ end
         @test timestamp(collapse(ohlc, month, first))[2] == Date(2000,2,1)
 
         # https://github.com/JuliaStats/TimeSeries.jl/issues/498
-        let  # quarter
-            ts = [
-                Date(2018, 1, 2),
-                Date(2018, 1, 3),
-                Date(2019, 1, 5),
-                Date(2019, 2, 6),
-            ]
-            ta = TimeArray(ts, 1:length(ts))
-            ta′ = collapse(ta, Dates.quarter, last)
-            @test values(ta′)    == [2, 4]
-            @test timestamp(ta′) == ts[[2, 4]]
+        if VERSION ≥ v"1.6"
+            let  # quarter
+                ts = [
+                    Date(2018, 1, 2),
+                    Date(2018, 1, 3),
+                    Date(2019, 1, 5),
+                    Date(2019, 2, 6),
+                ]
+                ta = TimeArray(ts, 1:length(ts))
+                ta′ = collapse(ta, Dates.quarter, last)
+                @test values(ta′)    == [2, 4]
+                @test timestamp(ta′) == ts[[2, 4]]
+            end
         end
         let  # week
             ts = [


### PR DESCRIPTION
Ref #498. 

This PR is the first part for fixing #498.
The following works are
1. Add a new signature of collapse to accept `Period` type.
2. Handling type promotion like `map` does.

@clouds56 Could you try this PR out?