### PR TITLE
Remove candletick series labels

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -149,6 +149,7 @@ end
         seriestype  := :shape
         seriescolor := colors′
         linecolor  --> colors′
+        label --> ""
         xseg, yseg
     end
 
@@ -157,6 +158,7 @@ end
         seriescolor       := colors
         markersize        := 1
         markerstrokewidth := 0
+        label --> ""
         hover             --> hovers
         xcenter, ycenter
     end


### PR DESCRIPTION
The current recipe produces a separate label for each bar, which completely clutters the plot if a user calls `plot(ta; legend = :topleft)` (or any other legend position). With this change no labels are produced by default, allowing the user to combine the candlestick plot with other plots and add a legend without having dozens of `y1, y2, y3`... entries in the legend.