### PR TITLE
Fix documentation error for TimeArray constructor 3

### DIFF
--- a/src/timearray.jl
+++ b/src/timearray.jl
@@ -15,7 +15,7 @@ abstract type AbstractTimeSeries{T,N,D} end
 
     TimeArray(timestamp, values[, colnames, meta = nothing])
     TimeArray(ta::TimeArray; timestamp, values, colnames, meta)
-    TimeArray(data::NamedTuple, timestamp = :datetime, meta)
+    TimeArray(data::NamedTuple; timestamp::Symbol, meta = nothing)
     TimeArray(table; timestamp::Symbol, timeparser::Callable = identity)
 
 The second constructor yields a new `TimeArray` with the new given fields.


### PR DESCRIPTION
Fixed an error in the documentation which suggested that the NamedTuple constructor for a TimeArray had a default value for the `timestamp` argument which was not in the implementation of the function.